### PR TITLE
Add a partition strategy based on an MD5 hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ It's possible that your topic and system are entirely ok with losing some messag
 
     The `partition_strategy` setting can be one of:
 
-    - `:round_robin`: (default) cycle through each partition starting from 0 at application start
+    - `:md5`: (default) provides even and deterministic distrbution of the messages over the available partitions based on an MD5 hash of the key
+    - `:round_robin`: cycle through each partition starting from 0 at application start
     - `:random`: select a random partition for each message
     - function: a given function to call to determine the correct partition
 

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -5,7 +5,7 @@ defmodule Kaffe.Config.Producer do
       producer_config: client_producer_config,
       client_name: config_get(:client_name, :kaffe_producer_client),
       topics: producer_topics,
-      partition_strategy: config_get(:partition_strategy, :round_robin),
+      partition_strategy: config_get(:partition_strategy, :md5),
     }
   end
 

--- a/lib/kaffe/partition_selector.ex
+++ b/lib/kaffe/partition_selector.ex
@@ -27,4 +27,11 @@ defmodule Kaffe.PartitionSelector do
   def random(total) do
     :crypto.rand_uniform(0, total)
   end
+
+  def md5(key, total) do
+    :crypto.hash(:md5, key)
+    |> :binary.bin_to_list
+    |> Enum.sum
+    |> rem(total)
+  end
 end

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -33,7 +33,8 @@ defmodule Kaffe.Producer do
     - `endpoints` - plaintext Kafka endpoints
     - `topics` - a list of Kafka topics to prep for producing
     - `partition_strategy` - the strategy to use when selecting the next partition.
-      Default `:round_robin`.
+      Default `:md5`.
+      - `:md5`: provides even and deterministic distrbution of the messages over the available partitions based on an MD5 hash of the key
       - `:round_robin` - Cycle through the available partitions
       - `:random` - Select a random partition
       - function - Pass a function as an argument that accepts five arguments and
@@ -143,6 +144,10 @@ defmodule Kaffe.Producer do
 
   defp choose_partition(_topic, _current_partition, partitions_count, _key, _value, :random) do
     Kaffe.PartitionSelector.random(partitions_count)
+  end
+
+  defp choose_partition(_topic, _current_partition, partitions_count, key, _value, :md5) do
+    Kaffe.PartitionSelector.md5(key, partitions_count)
   end
 
   defp choose_partition(topic, current_partition, partitions_count, key, value, fun) when is_function(fun) do

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -14,7 +14,7 @@ defmodule Kaffe.Config.ProducerTest do
         ],
         topics: ["kaffe-test"],
         client_name: :kaffe_producer_client,
-        partition_strategy: :round_robin,
+        partition_strategy: :md5,
       }
 
       assert Kaffe.Config.Producer.configuration == expected

--- a/test/kaffe/partition_selector_test.exs
+++ b/test/kaffe/partition_selector_test.exs
@@ -19,4 +19,15 @@ defmodule Kaffe.PartitionSelectorTest do
       assert Enum.member?(0..2, PartitionSelector.random(3))
     end
   end
+
+  describe "md5/2" do
+    test "computes the remainder of an md5 hash of the key" do
+
+      assert PartitionSelector.md5("key1", 10) == PartitionSelector.md5("key1", 10),
+        "Partition should be deterministic"
+
+      assert PartitionSelector.md5("key1", 10) != PartitionSelector.md5("key2", 10),
+        "Partition should not be fixed"
+    end
+  end
 end


### PR DESCRIPTION
The hash is computed from the key and distributed over the available
partitions using modulo division.

I tried to follow the pattern of the existing tests. I also think I fixed the test for the random strategy.