### PR TITLE
Add a group subscriber capabilty to Kaffe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ erl_crash.dump
 *.ez
 
 /priv
+.tool-versions

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,13 @@ use Mix.Config
 
 config :kaffe,
   kafka_mod: :brod,
-  group_subscriber_mod: :brod_group_subscriber
+  group_subscriber_mod: :brod_group_subscriber,
+  group_coordinator_mod: :brod_group_coordinator
+
+# config :logger, :console,
+#   level: :debug,
+#   format: "$date $time $metadata[$level] $message\n",
+#   metadata: [:module]
+config :logger, backends: []
 
 import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,15 +5,17 @@ config :kaffe,
   group_subscriber_mod: TestBrodGroupSubscriber,
   test_partition_count: 17,
   consumer: [
-    endpoints: [kafka_test: 9092],
+    endpoints: [kafka: 9092],
     topics: ["kaffe-test"],
     consumer_group: "kaffe-test-group",
     message_handler: SilentMessage,
     async_message_ack: false,
     offset_commit_interval_seconds: 10,
     start_with_earliest_message: true,
+    rebalance_delay_ms: 1_000,
+    max_bytes: 10_000
   ],
   producer: [
-    endpoints: [kafka_test: 9092],
+    endpoints: [kafka: 9092],
     topics: ["kaffe-test"]
   ]

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -9,6 +9,8 @@ defmodule Kaffe.Config.Consumer do
       consumer_config: client_consumer_config,
       message_handler: message_handler,
       async_message_ack: async_message_ack,
+      rebalance_delay_ms: rebalance_delay_ms,
+      max_bytes: max_bytes
     }
   end
 
@@ -32,6 +34,14 @@ defmodule Kaffe.Config.Consumer do
       offset_commit_policy: :commit_to_kafka_v2,
       offset_commit_interval_seconds: config_get(:offset_commit_interval_seconds, 5),
     ]
+  end
+
+  def rebalance_delay_ms do
+   config_get(:rebalance_delay_ms, 10_000)
+  end
+
+  def max_bytes do
+   config_get(:max_bytes, 1_000_000)
   end
 
   def client_consumer_config do

--- a/lib/kaffe/group_member/manager/group_manager.ex
+++ b/lib/kaffe/group_member/manager/group_manager.ex
@@ -1,0 +1,72 @@
+defmodule Kaffe.GroupManager do
+  @moduledoc """
+  This is the main process for launching group members and workers.
+
+  The process begins by starting the client connection to Kafka. Then, group
+  members are created for each of the configured topics.
+
+  This is also the place where subscribers get the PID for a Worker.
+  """
+  
+  use GenServer
+
+  alias Kaffe.GroupMemberSupervisor
+  alias Kaffe.WorkerSupervisor
+
+  require Logger
+
+  defmodule State do
+    defstruct supervisor_pid: nil,
+      subscriber_name: nil,
+      consumer_group: nil,
+      topics: nil,
+      offset: nil
+  end
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [self()])  
+  end
+
+  ## Callbacks
+
+  def init([supervisor_pid]) do
+    Logger.info "event#startup=#{inspect self()}"
+
+    config = Kaffe.Config.Consumer.configuration
+
+    :ok = kafka().start_client(config.endpoints, config.subscriber_name, config.consumer_config)
+
+    GenServer.cast(self(), {:start_group_members})
+
+    {:ok, %State{supervisor_pid: supervisor_pid,
+                subscriber_name: config.subscriber_name,
+                consumer_group: config.consumer_group,
+                topics: config.topics,
+                offset: Kaffe.Config.Consumer.begin_offset}}
+  end
+
+  def handle_cast({:start_group_members}, state) do
+
+    Logger.debug "Starting worker supervisors for group manager: #{inspect self()}"
+    
+    {:ok, worker_supervisor_pid} = GroupMemberSupervisor.start_worker_supervisor(state.supervisor_pid)
+    {:ok, worker_manager_pid} = WorkerSupervisor.start_worker_manager(worker_supervisor_pid)
+
+    Enum.each(state.topics, fn(topic) ->
+      Logger.debug "Starting group member for topic: #{topic}"
+      {:ok, _pid} = GroupMemberSupervisor.start_group_member(
+        state.supervisor_pid,
+        state.subscriber_name,
+        state.consumer_group,
+        worker_manager_pid,
+        topic,
+        state.offset)
+    end)
+    {:noreply, state}
+  end
+
+  defp kafka do
+    Application.get_env(:kaffe, :kafka_mod, :brod)
+  end
+
+end

--- a/lib/kaffe/group_member/manager/group_member_supervisor.ex
+++ b/lib/kaffe/group_member/manager/group_member_supervisor.ex
@@ -1,0 +1,34 @@
+defmodule Kaffe.GroupMemberSupervisor do
+  @moduledoc """
+  The top-level supervisor for group members and subscribers.
+  """
+
+  use Supervisor
+
+  require Logger
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok)
+  end
+
+  def start_worker_supervisor(supervisor_pid) do
+    Supervisor.start_child(supervisor_pid, supervisor(Kaffe.WorkerSupervisor, []))
+  end
+
+  def start_group_member(supervisor_pid, subscriber_name, consumer_group,
+      worker_manager_pid, topic, configured_offset) do
+    Supervisor.start_child(supervisor_pid, worker(Kaffe.GroupMember,
+      [subscriber_name, consumer_group, worker_manager_pid, topic, configured_offset], id: topic))
+  end
+
+  def init(:ok) do
+    Logger.debug "event#starting"
+
+    children = [
+      worker(Kaffe.GroupManager, [])
+    ]
+
+    # If we get a failure, we need to reset so the states are all consistent.
+    supervise(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
+  end
+end

--- a/lib/kaffe/group_member/subscriber/group_member.ex
+++ b/lib/kaffe/group_member/subscriber/group_member.ex
@@ -1,0 +1,152 @@
+defmodule Kaffe.GroupMember do
+  @moduledoc """
+  Consume messages from a Kafka topic for a consumer group.
+
+  The actual consumption is delegated to a series of subscribers, see
+  `Kaffe.Subscriber`.
+
+  The subscribers are assigned generations. Each generation represents a
+  specific configuration. In order to allow the partitions to be rebalanced on
+  startup, there is a delay between receiving a set of assignments associated
+  with that generation and actually creating the subscribers. If a new
+  generation is received in the mean time, the older generation is discarded.
+
+  See: https://github.com/klarna/brod/blob/master/src/brod_group_member.erl
+
+  Also: https://github.com/klarna/brucke/blob/master/src/brucke_member.erl
+
+  The `brod_group_member` behavior is used. 
+  """
+
+  use GenServer
+
+  @behaviour :brod_group_member
+
+  alias Kaffe.WorkerManager
+
+  require Logger
+
+  defmodule State do
+    defstruct subscribers: [],
+      subscriber_name: nil,
+      group_coordinator_pid: nil,
+      consumer_group: nil,
+      worker_manager_pid: nil,
+      topic: nil,
+      configured_offset: nil,
+      current_gen_id: nil
+  end
+
+  def start_link(subscriber_name, consumer_group, worker_manager_pid, topic, configured_offset) do
+    GenServer.start_link(__MODULE__, [subscriber_name, consumer_group,
+      worker_manager_pid, topic, configured_offset])
+  end
+
+  def init([subscriber_name, consumer_group, worker_manager_pid, topic, configured_offset]) do
+
+    :ok = kafka().start_consumer(subscriber_name, topic, [])
+    {:ok, pid} = group_coordinator().start_link(subscriber_name, consumer_group,
+      [topic], _group_config = [], __MODULE__, self())
+
+    Logger.info "event#init group_coordinator=#{inspect pid} subscriber_name=#{subscriber_name} consumer_group=#{consumer_group}"
+
+    {:ok, %State{subscriber_name: subscriber_name,
+                group_coordinator_pid: pid,
+                consumer_group: consumer_group,
+                worker_manager_pid: worker_manager_pid,
+                topic: topic,
+                configured_offset: configured_offset}}
+  end
+
+  def get_committed_offsets(_group_member_pid, _topic_partitions) do
+    # Should not receive this
+    Logger.warn "status#get_committed_offsets"
+  end
+
+  def assign_partitions(_pid, _members, _topic_partitions) do
+    # Should not receive this
+    Logger.warn "status#assign_partitions"
+  end
+
+  def assignments_received(pid, _member_id, generation_id, assignments) do
+    GenServer.cast(pid, {:assignments_received, generation_id, assignments})
+  end
+
+  def assignments_revoked(pid) do
+    GenServer.cast(pid, {:assignments_revoked})
+  end
+
+  # Handle the partition assignments. Wait the configured duration before allocating the
+  # subscribers to give each consumer a chance to handle the latest generation of the
+  # configuration.
+  def handle_cast({:assignments_received, gen_id, assignments}, state) do
+    Logger.info "event#assignments_received=#{gen_id}"
+    Process.send_after(self(), {:allocate_subscribers, gen_id, assignments}, rebalance_delay())
+    {:noreply, %{state | current_gen_id: gen_id}}
+  end
+  def handle_cast({:assignments_revoked}, state) do
+    Logger.info "event#assignments_revoked"
+    Enum.each(state.subscribers, fn (s) ->
+      Logger.debug "Stopping subscriber: #{inspect s}"
+      Kaffe.Subscriber.stop(s)
+    end)
+
+    {:noreply, %{state | :subscribers => []}}
+  end
+
+  # If we're not at the latest generation, discard the assignment for whatever is next.
+  def handle_info({:allocate_subscribers, gen_id, _assignments}, %{current_gen_id: current_gen_id} = state)
+      when gen_id < current_gen_id do
+    Logger.info "Discarding old generation #{gen_id} for current generation: #{current_gen_id}"
+    {:noreply, state}
+  end
+  # If we are at the latest, allocate a subscriber per partition.
+  def handle_info({:allocate_subscribers, gen_id, assignments}, state) do
+
+    Logger.info "event#allocate_subscribers=#{inspect self()} generation_id=#{gen_id}"
+
+    subscribers = Enum.map(assignments, fn (assignment) ->
+
+      {:brod_received_assignment, topic, partition, offset} = assignment
+
+      worker_pid = WorkerManager.worker_for(state.worker_manager_pid, partition)
+
+      {:ok, pid} = subscriber().subscribe(
+        state.subscriber_name,
+        state.group_coordinator_pid,
+        worker_pid,
+        gen_id,
+        topic,
+        partition,
+        compute_offset(offset, state.configured_offset))
+
+      pid
+    end)
+
+    {:noreply, %{state | :subscribers => subscribers}}
+  end
+
+  defp compute_offset(:undefined, configured_offset) do
+    [begin_offset: configured_offset]
+  end
+  defp compute_offset(offset, _configured_offset) do
+    [begin_offset: offset]
+  end
+
+  defp rebalance_delay do
+    Kaffe.Config.Consumer.configuration.rebalance_delay_ms
+  end
+
+  defp group_coordinator do
+    Application.get_env(:kaffe, :group_coordinator_mod, :brod_group_coordinator)
+  end
+
+  defp kafka do
+    Application.get_env(:kaffe, :kafka_mod, :brod)
+  end
+
+  defp subscriber do
+    Application.get_env(:kaffe, :subscriber_mod, Kaffe.Subscriber)
+  end
+
+end

--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -1,0 +1,107 @@
+defmodule Kaffe.Subscriber do
+  @moduledoc """
+  Consume messages from a single partition of a single Kafka topic.
+  
+  Assignments are received from a group consumer member, `Kaffe.GroupMember`.
+
+  Messages are delegated to `Kaffe.Worker`.
+
+  The result from the worker is expected to be `:ok` and anything else
+  will be an error.
+
+  See: https://github.com/klarna/brucke/blob/master/src/brucke_member.erl
+  """
+
+  use GenServer
+
+  alias Kaffe.Worker
+
+  require Logger
+
+  require Record
+  import Record, only: [defrecord: 2, extract: 2]
+  defrecord :kafka_message_set, extract(:kafka_message_set, from_lib: "brod/include/brod.hrl")
+  defrecord :kafka_message, extract(:kafka_message, from_lib: "brod/include/brod.hrl")
+
+  defmodule State do
+    defstruct subscriber_pid: nil, group_coordinator_pid: nil, gen_id: nil, worker_pid: nil,
+      topic: nil, partition: nil, ack_offset: nil
+  end
+
+  def subscribe(subscriber_name, group_coordinator_pid, worker_pid,
+      gen_id, topic, partition, ops) do
+    GenServer.start_link(__MODULE__, [subscriber_name, group_coordinator_pid, worker_pid,
+        gen_id, topic, partition, ops])
+  end
+
+  def stop(subscriber_pid) do
+    Logger.debug "event#stopping=#{inspect self()}"
+    GenServer.stop(subscriber_pid)
+  end
+
+  def ack_messages(subscriber_pid) do
+    GenServer.cast(subscriber_pid, {:ack_messages})
+  end
+
+  def init([subscriber_name, group_coordinator_pid, worker_pid,
+      gen_id, topic, partition, ops]) do
+    {:ok, subscriber_pid} = kafka().subscribe(subscriber_name, self(), topic, partition,
+      ops ++ subscriber_ops())
+    {:ok, %State{subscriber_pid: subscriber_pid, group_coordinator_pid: group_coordinator_pid,
+            worker_pid: worker_pid, gen_id: gen_id, topic: topic, partition: partition,
+            ack_offset: nil}}
+  end
+
+  def handle_info({_pid, message_set}, state) do
+
+    messages = message_set
+    |> kafka_message_set
+    |> Enum.into(%{})
+    |> Map.get(:messages)
+    |> Enum.map(fn (message) ->
+      compile_message(message, state.topic, state.partition)
+    end)
+
+    offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
+
+    Logger.debug "Sending message set to worker: #{inspect state.worker_pid}"
+    Worker.process_messages(state.worker_pid, messages)
+
+    {:noreply, %{state | ack_offset: offset}}
+  end
+  def handle_info({'DOWN', _ref, _process, _pid, reason}, _state) do
+    Logger.warn "event#down=#{inspect self()} reason=#{inspect reason}"
+  end
+
+  def handle_cast({:ack_messages}, state) do
+
+    # Update the offsets in the group
+    :ok = group_coordinator().ack(state.group_coordinator_pid, state.gen_id,
+        state.topic, state.partition, state.ack_offset)
+    # Request more messages from the consumer
+    :ok = kafka().consume_ack(state.subscriber_pid, state.ack_offset)
+
+    {:noreply, state}
+  end
+
+  defp compile_message(msg, topic, partition) do
+    Map.merge(%{topic: topic, partition: partition}, kafka_message_to_map(msg))
+  end
+
+  defp kafka_message_to_map(msg) do
+    Enum.into(kafka_message(msg), %{})
+  end
+
+  defp kafka do
+    Application.get_env(:kaffe, :kafka_mod, :brod)
+  end
+
+  defp group_coordinator do
+    Application.get_env(:kaffe, :group_coordinator_mod, :brod_group_coordinator)
+  end
+
+  defp subscriber_ops do
+    [max_bytes: Kaffe.Config.Consumer.configuration.max_bytes]
+  end
+
+end

--- a/lib/kaffe/group_member/worker/worker.ex
+++ b/lib/kaffe/group_member/worker/worker.ex
@@ -1,0 +1,45 @@
+defmodule Kaffe.Worker do
+  @moduledoc """
+  A worker is assigned a single partition across topics for the client. This is
+  so we effectively serialize the processing of any single key across topics.
+
+  Processing the message set is delegated to the configured message handler. It
+  is responsible for any error handling. The message handler must define a
+  `handle_messages` function (*note* the pluralization!) to accept a list of
+  messages.
+
+  The result of handle message is sent back to the subscriber.
+  """
+
+  alias Kaffe.Subscriber
+
+  require Logger
+
+  def start_link(message_handler, partition) do
+    GenServer.start_link(__MODULE__, [message_handler, partition], name: :"partition_worker_#{partition}")
+  end
+
+  def init([message_handler, partition]) do
+    Logger.info "event#starting=#{inspect self()} source=#{__MODULE__}"
+    {:ok, %{message_handler: message_handler,
+            partition: partition}}
+  end
+
+  def process_messages(pid, messages) do
+    GenServer.cast(pid, {:process_messages, self(), messages})
+  end
+
+  def handle_cast({:process_messages, subscriber_pid, messages},
+      %{message_handler: message_handler} = state) do
+
+    :ok = apply(message_handler, :handle_messages, [messages])
+    Subscriber.ack_messages(subscriber_pid)
+
+    {:noreply, state}
+  end
+
+  def terminate(reason, _state) do
+    Logger.info "event#terminate=#{inspect self()} reason=#{inspect reason}"
+  end
+
+end

--- a/lib/kaffe/group_member/worker/worker_manager.ex
+++ b/lib/kaffe/group_member/worker/worker_manager.ex
@@ -1,0 +1,62 @@
+defmodule Kaffe.WorkerManager do
+  @moduledoc """
+  Manage partition-to-worker assignments. Subscribers get workers from here.
+
+  This process manages the workers, while delegating to
+  `Kaffe.WorkerSupervisor` to start each worker under supervision.
+
+  The table of workers is stored in an ETS table, `:workers`.
+  """
+  
+  use GenServer
+
+  alias Kaffe.WorkerSupervisor
+
+  require Logger
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [self()])  
+  end
+
+  def worker_for(pid, partition) do
+    GenServer.call(pid, {:worker_for, partition})
+  end
+
+  ## Callbacks
+
+  def init([supervisor_pid]) do
+    Logger.info "event#starting=#{inspect self()} for supervisor=#{inspect supervisor_pid}"
+
+    worker_table = :ets.new(:workers, [:set, :protected])
+
+    {:ok, %{supervisor_pid: supervisor_pid, worker_table: worker_table}}
+  end
+  
+  def handle_call({:worker_for, partition}, _from, state) do
+    worker_pid = allocate_worker(partition, state)
+    {:reply, worker_pid, state}
+  end
+
+  ## Private
+
+  defp allocate_worker(partition, %{worker_table: worker_table} = state) do
+    case :ets.lookup(worker_table, partition) do
+      [{^partition, worker_pid}] -> worker_pid
+      [] -> start_worker(partition, state)
+    end
+  end
+
+  defp start_worker(partition, %{supervisor_pid: supervisor_pid} = state) do
+    config = Kaffe.Config.Consumer.configuration
+    Logger.debug "Creating worker for partition: #{partition}"
+    WorkerSupervisor.start_worker(supervisor_pid, config.message_handler, partition)
+    |> capture_worker(partition, state)
+  end
+
+  defp capture_worker({:ok, pid}, partition, %{worker_table: worker_table}) do
+    Logger.debug "Captured new worker: #{inspect pid} for partition: #{partition}"
+    true = :ets.insert(worker_table, {partition, pid})
+    pid
+  end
+
+end

--- a/lib/kaffe/group_member/worker/worker_supervisor.ex
+++ b/lib/kaffe/group_member/worker/worker_supervisor.ex
@@ -1,0 +1,35 @@
+defmodule Kaffe.WorkerSupervisor do
+  @moduledoc """
+  Supervise the individual workers.
+  """
+
+  use Supervisor
+
+  require Logger
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok)
+  end
+
+  def start_worker_manager(pid) do
+    Supervisor.start_child(pid, worker(Kaffe.WorkerManager, []))
+  end
+
+  def start_worker(pid, message_handler, partition) do
+    Logger.debug "Starting worker for partition: #{partition}"
+    Supervisor.start_child(pid,
+      worker(Kaffe.Worker, [message_handler, partition], id: partition))
+  end
+
+  def init(:ok) do
+    Logger.info "event#startup=#{inspect self()}"
+
+    children = [
+    ]
+
+    # If anything fails, the state is inconsistent with the state of
+    # `Kaffe.Subscriber` and `Kaffe.GroupMember`. We need the failure
+    # to cascade all the way up so that they are terminated.
+    supervise(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"brod": {:hex, :brod, "2.3.1", "c80036a92fff8a6be1182293c2cf353fa13e7deb11747d09fe0ae3fcd8d10f54", [:make, :rebar, :rebar3], [{:kafka_protocol, "0.9.1", [hex: :kafka_protocol, optional: false]}, {:supervisor3, "1.1.5", [hex: :supervisor3, optional: false]}]},
   "kafka_protocol": {:hex, :kafka_protocol, "0.9.1", "8e943f26590a1ae034422fb8305f64a1aa21ff6dea4fb51e36b702c410861205", [:make, :rebar, :rebar3], [{:snappyer, "1.2.0", [hex: :snappyer, optional: false]}]},
+  "logfmt": {:hex, :logfmt, "3.2.0", "887a091adad28acc6e4d8b3d3bce177b934e7c61e7655c86946410f44aca6d84", [:mix], []},
+  "metrix": {:git, "https://github.com/rwdaigle/metrix.git", "a6738df9346da0412ca68f82a24a67d2a32b066e", [branch: "master"]},
   "snappyer": {:hex, :snappyer, "1.2.0", "4761f475c53fec4a027dc90ea0626a735e3d276bfcfaf9a8dc4c7bbda4d1e058", [:make, :rebar, :rebar3], []},
   "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], []}}

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -4,7 +4,7 @@ defmodule Kaffe.Config.ConsumerTest do
   describe "configuration/0" do
     test "correct settings are extracted" do
       expected = %{
-        endpoints: [kafka_test: 9092],
+        endpoints: [kafka: 9092],
         subscriber_name: :"kaffe-test-group",
         consumer_group: "kaffe-test-group",
         topics: ["kaffe-test"],
@@ -19,6 +19,8 @@ defmodule Kaffe.Config.ConsumerTest do
         ],
         message_handler: SilentMessage,
         async_message_ack: false,
+        rebalance_delay_ms: 1_000,
+        max_bytes: 10_000
       }
 
       assert Kaffe.Config.Consumer.configuration == expected

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -4,7 +4,7 @@ defmodule Kaffe.Config.ProducerTest do
   describe "configuration/0" do
     test "correct settings are extracted" do
       expected = %{
-        endpoints: [kafka_test: 9092],
+        endpoints: [kafka: 9092],
         producer_config: [
           auto_start_producers: true,
           allow_topic_auto_creation: false,

--- a/test/kaffe/group_member/subscriber/group_member_test.exs
+++ b/test/kaffe/group_member/subscriber/group_member_test.exs
@@ -1,0 +1,53 @@
+defmodule Kaffe.GroupMemberTest do
+  @moduledoc """
+  First setup a topic like the one in `script/test-setup.sh`
+  """
+
+  use ExUnit.Case
+  
+  @moduletag :e2e
+
+  defmodule TestSubscriber do
+    def subscribe(_subscriber_name, group_coordinator_pid, _worker_pid, _gen_id, topic, partition, _ops) do
+      send :test_case, {:subscribe, group_coordinator_pid, topic, partition}
+      {:ok, self()}
+    end
+  end
+
+  setup do
+    Application.put_env(:kaffe, :kafka_mod, :brod)
+    Application.put_env(:kaffe, :subscriber_mod, TestSubscriber)
+  end
+
+
+  # Start two consumers and verify that they receive different partition assignments
+  test "startup" do
+    Process.register(self(), :test_case)
+    {:ok, _pid} = Kaffe.GroupMemberSupervisor.start_link()
+    {:ok, _pid} = Kaffe.GroupMemberSupervisor.start_link()
+
+    :timer.sleep 11_000
+
+    assignments = Enum.reduce(0..31, %{}, fn partition, map ->
+      receive do
+        {:subscribe, group_coordinator_pid, _topic, ^partition} ->
+          {_get, res} = Map.get_and_update(map, group_coordinator_pid, fn
+            nil ->
+              {nil, [partition]}
+            list ->
+              {list, [partition | list]}
+          end)
+          res
+      end
+    end)
+
+    [list1, list2] = Map.values(assignments)
+
+    assert Enum.to_list(0..31) |> Enum.sort == Enum.sort(list1 ++ list2)
+    assert length(list1) == length(list2)
+    assert list1 == list1 -- list2
+    assert list2 == list2 -- list1
+
+  end
+
+end

--- a/test/kaffe/group_member/worker/worker_test.exs
+++ b/test/kaffe/group_member/worker/worker_test.exs
@@ -1,0 +1,23 @@
+defmodule Kaffe.WorkerTest do
+
+  use ExUnit.Case
+
+  alias Kaffe.Worker
+  
+  defmodule TestHandler do
+    def handle_messages(messages) do
+      send :test_case, {:handle_messages, messages}
+      :ok
+    end
+  end
+
+  test "use list handler" do
+    Process.register(self(), :test_case)
+    {:ok, worker_pid} = Worker.start_link(TestHandler, 0)
+    Worker.process_messages(worker_pid, [%{message: :one}, %{message: :two}])
+
+    :timer.sleep 100
+
+    assert_received {:handle_messages, [%{message: :one}, %{message: :two}]}
+  end
+end

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -8,7 +8,7 @@ defmodule Kaffe.ProducerTest do
   setup do
     %{
       client_name: :client,
-      endpoints: [kafka_test: 9092],
+      endpoints: [kafka: 9092],
       producer_config: Kaffe.Config.Producer.default_client_producer_config,
       partition_strategy: :round_robin,
       topics: ["topic", "topic2"],

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+ExUnit.configure exclude: [:e2e]


### PR DESCRIPTION
Using [Brucke](https://github.com/klarna/brucke/blob/master/src/brucke_member.erl) for guidance, implement the `:brod_group_member` behavior.

This enables per-partition workers that receive batches of messages for
much higher throughput.

Either multi-message or single message handlers are supported, based on
the handler defining `handle_messages/1` or `handle_message/1`.

To use this consumer instead of the existing consumer, replace:

```
    worker(Kaffe.Consumer, [])
```

with:

```
    supervisor(Kaffe.GroupMemberSupervisor, [])
```

This should otherwise allow existing consumers to work as they do today.

Alternatively, implement `handle_messages/1` in the `message_handler`
module and a list of messages will be passed in, instead of a single message.

Definitely use the `max_bytes` consumer option to limit the number of bytes
of messages fetched from Kafka. Start with 100,000 and then move up to keep
the consumer from using too much memory.

This could use some more testing around tracking offsets and ensuring there
is a single worker per partition, but I wanted to get feedback while those items
are worked.

I tried to leverage the existing configuration as much as possible. I do think that
the `rebalance_delay_ms` should just be in seconds instead. Also, the
`async_message_ack` doesn't yet apply (and may not make sense).

I also added a dependency on Metrix, but that may not be something we want
to keep.

Fixes #20