### PR TITLE
Add support for Kafka's auto offset reset

### DIFF
--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -13,6 +13,7 @@ defmodule Kaffe.Config.Consumer do
       max_bytes: max_bytes,
       subscriber_retries: subscriber_retries(),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(),
+      offset_reset_policy: offset_reset_policy(),
     }
   end
 
@@ -74,6 +75,10 @@ defmodule Kaffe.Config.Consumer do
       true -> :earliest
       false -> -1
     end
+  end
+
+  def offset_reset_policy do
+    config_get(:offset_reset_policy, :reset_by_subscriber)
   end
 
   def maybe_heroku_kafka_ssl do

--- a/lib/kaffe/group_member/manager/group_manager.ex
+++ b/lib/kaffe/group_member/manager/group_manager.ex
@@ -39,8 +39,7 @@ defmodule Kaffe.GroupManager do
     {:ok, %State{supervisor_pid: supervisor_pid,
                 subscriber_name: config.subscriber_name,
                 consumer_group: config.consumer_group,
-                topics: config.topics,
-                offset: Kaffe.Config.Consumer.begin_offset}}
+                topics: config.topics}}
   end
 
   def handle_cast({:start_group_members}, state) do
@@ -59,8 +58,7 @@ defmodule Kaffe.GroupManager do
         state.subscriber_name,
         state.consumer_group,
         worker_manager_pid,
-        topic,
-        state.offset)
+        topic)
     end)
 
     {:noreply, state}

--- a/lib/kaffe/group_member/manager/group_member_supervisor.ex
+++ b/lib/kaffe/group_member/manager/group_member_supervisor.ex
@@ -16,9 +16,9 @@ defmodule Kaffe.GroupMemberSupervisor do
   end
 
   def start_group_member(supervisor_pid, subscriber_name, consumer_group,
-      worker_manager_pid, topic, configured_offset) do
+      worker_manager_pid, topic) do
     Supervisor.start_child(supervisor_pid, worker(Kaffe.GroupMember,
-      [subscriber_name, consumer_group, worker_manager_pid, topic, configured_offset],
+      [subscriber_name, consumer_group, worker_manager_pid, topic],
       id: :"group_member_#{subscriber_name}_#{topic}"))
   end
 

--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -4,12 +4,20 @@ defmodule Kaffe.Subscriber do
   
   Assignments are received from a group consumer member, `Kaffe.GroupMember`.
 
-  Messages are delegated to `Kaffe.Worker`.
+  Messages are delegated to `Kaffe.Worker`. The worker is expected to cast back
+  a response, at which time the stored offset will be acked back to Kafka.
 
-  The result from the worker is expected to be `:ok` and anything else
-  will be an error.
+  The options (`ops`) to `subscribe/7` may include the beginning offset
+  using `:begin_offset`.
+
+  The subscriber reads the following options out of the configuration:
+
+      - `max_bytes` - The maximum number of message bytes to receive in a batch
+      - `offset_reset_policy` - The native `auto.offset.reset` option,
+          either `:reset_to_earliest` or `:reset_to_latest`.
 
   See: https://github.com/klarna/brucke/blob/master/src/brucke_member.erl
+  Also: https://github.com/klarna/brod/blob/master/src/brod_consumer.erl
   """
 
   use GenServer
@@ -140,7 +148,8 @@ defmodule Kaffe.Subscriber do
   end
 
   defp subscriber_ops do
-    [max_bytes: Kaffe.Config.Consumer.configuration.max_bytes]
+    [max_bytes: Kaffe.Config.Consumer.configuration.max_bytes,
+     offset_reset_policy: Kaffe.Config.Consumer.configuration.offset_reset_policy]
   end
 
   defp max_retries do

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -1,7 +1,15 @@
 defmodule Kaffe.Config.ConsumerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   describe "configuration/0" do
+
+    setup do
+      consumer_config = Application.get_env(:kaffe, :consumer)
+      |> Keyword.delete(:offset_reset_policy)
+      |> Keyword.put(:start_with_earliest_message, true)
+      Application.put_env(:kaffe, :consumer, consumer_config)
+    end
+
     test "correct settings are extracted" do
       expected = %{
         endpoints: [kafka: 9092],
@@ -23,9 +31,22 @@ defmodule Kaffe.Config.ConsumerTest do
         max_bytes: 10_000,
         subscriber_retries: 1,
         subscriber_retry_delay_ms: 5,
+        offset_reset_policy: :reset_by_subscriber
       }
 
       assert Kaffe.Config.Consumer.configuration == expected
     end
+  end
+
+  describe "offset_reset_policy" do
+
+    test "computes correctly from start_with_earliest_message == true" do
+      consumer_config = Application.get_env(:kaffe, :consumer)
+      |> Keyword.delete(:offset_reset_policy)
+      Application.put_env(:kaffe, :consumer, consumer_config)
+
+      assert Kaffe.Config.Consumer.configuration.offset_reset_policy == :reset_by_subscriber
+    end
+
   end
 end

--- a/test/kaffe/group_member/subscriber/group_member_test.exs
+++ b/test/kaffe/group_member/subscriber/group_member_test.exs
@@ -46,8 +46,7 @@ defmodule Kaffe.GroupMemberTest do
 
     Process.register(self(), :test_case)
     
-    {:ok, pid} = GroupMember.start_link("subscriber_name", "consumer_group",
-      self(), "topic", :earliest)
+    {:ok, pid} = GroupMember.start_link("subscriber_name", "consumer_group", self(), "topic")
 
     GroupMember.assignments_received(pid, self(), 1, [{:brod_received_assignment, "topic", 0, 1}])
 
@@ -63,8 +62,7 @@ defmodule Kaffe.GroupMemberTest do
 
     Process.register(self(), :test_case)
     
-    {:ok, pid} = GroupMember.start_link("subscriber_name", "consumer_group",
-      self(), "topic", :earliest)
+    {:ok, pid} = GroupMember.start_link("subscriber_name", "consumer_group", self(), "topic")
 
     GroupMember.assignments_received(pid, self(), 1, [{:brod_received_assignment, "topic", 0, 1}])
 
@@ -83,8 +81,7 @@ defmodule Kaffe.GroupMemberTest do
 
     Process.register(self(), :test_case)
     
-    {:ok, pid} = GroupMember.start_link("subscriber_name", "consumer_group",
-      self(), "topic", :earliest)
+    {:ok, pid} = GroupMember.start_link("subscriber_name", "consumer_group", self(), "topic")
 
     GroupMember.assignments_received(pid, self(), 1, [{:brod_received_assignment, "topic", 0, 1}])
 


### PR DESCRIPTION
The Brod option is set through the `:offset_reset_policy` option.

The Kafka option is [`auto.offset.reset`](https://kafka.apache.org/documentation/#newconsumerconfigs).

The supported options are `:reset_to_earliest` and `:reset_to_latest`.

If `:offset_reset_policy` is not provided, but
`start_with_earliest_message` is `true`, it is as if
`:offset_reset_policy` was set to `:reset_to_earliest`.

Is this a sensible default? If not, what would be better?

I'd like to ensure this works for our known use cases.

Fixes #27