### PR TITLE
Support batch producing to Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An opinionated, highly specific, Elixir wrapper around brod: the Erlang Kafka cl
 
       ```elixir
       def deps do
-        [{:kaffe, "~> 0.5"}]
+        [{:kaffe, "~> 1.0"}]
       end
       ```
 
@@ -151,9 +151,9 @@ Batch message consumers receive a list of messages and work as part of the `:bro
   3. Add `Kaffe.GroupMemberSupervisor` as a supervisor in your
      supervision tree
 
-    ```elixir
-    supervisor(Kaffe.GroupMemberSupervisor, [])
-    ```
+       ```elixir
+       supervisor(Kaffe.GroupMemberSupervisor, [])
+       ```
 
 ### async message acknowledgement
 
@@ -202,14 +202,13 @@ It's possible that your topic and system are entirely ok with losing some messag
           topics: ["kafka-topic"],
 
           # optional
-          partition_strategy: :round_robin
+          partition_strategy: :md5
         ]
       ```
 
     The `partition_strategy` setting can be one of:
 
     - `:md5`: (default) provides even and deterministic distrbution of the messages over the available partitions based on an MD5 hash of the key
-    - `:round_robin`: cycle through each partition starting from 0 at application start
     - `:random`: select a random partition for each message
     - function: a given function to call to determine the correct partition
 
@@ -224,7 +223,7 @@ It's possible that your topic and system are entirely ok with losing some messag
         topics: ["kafka-topic"],
 
         # optional
-        partition_strategy: :round_robin
+        partition_strategy: :md5
       ]
     ```
 
@@ -235,7 +234,7 @@ It's possible that your topic and system are entirely ok with losing some messag
     - `KAFKA_CLIENT_CERT_KEY`
     - `KAFKA_TRUSTED_CERT`
 
-2. Add `Kaffe.Producer` as a worker in your supervision tree.
+2. Start `Kaffe.Producer` with your application
 
       ```elixir
       worker(Kaffe.Producer, [])
@@ -245,7 +244,15 @@ It's possible that your topic and system are entirely ok with losing some messag
 
 Currently only synchronous message production is supported.
 
-Once the `Kaffe.Producer` has started there are three ways to produce:
+Once the `Kaffe.Producer` has started there are several ways to produce:
+
+- `topic`/`message_list` - Produce each message in the list to the given `topic`. The messages are produced to the correct partition based on the configured partitioning strategy.
+
+    Each item in the list is a tuple of the key and value: `{key, value}`.
+
+    ```elixir
+    Kaffe.Producer.produce_sync("topic", [{"key1", "value1"}, {"key2", "value2"}])
+    ```
 
 - `key`/`value` - The key/value will be produced to the first topic given to the producer when it was started. The partition will be selected with the chosen strategy or given function.
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,7 +3,7 @@ use Mix.Config
 config :kaffe,
   kafka_mod: TestBrod,
   group_subscriber_mod: TestBrodGroupSubscriber,
-  test_partition_count: 17,
+  test_partition_count: 32,
   consumer: [
     endpoints: [kafka: 9092],
     topics: ["kaffe-test"],

--- a/lib/kaffe.ex
+++ b/lib/kaffe.ex
@@ -4,4 +4,24 @@ defmodule Kaffe do
 
   **NOTE**: Although we're using this in production at Spreedly it is still under active development. The API may change and there may be serious bugs we've yet to encounter.
   """
+
+  use Application
+
+  require Logger
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    Logger.debug "event#start=#{__MODULE__}"
+    if Application.get_env(:kaffe, :producer) do
+      Logger.debug "event#start_producer_client=#{__MODULE__}"
+      Kaffe.Producer.start_producer_client()
+    end
+
+    children = [
+    ]
+
+    opts = [strategy: :one_for_one, name: Kaffe.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Kaffe.Mixfile do
 
   def project do
     [app: :kaffe,
-     version: "0.5.0",
+     version: "1.0.0",
      description: "An opinionated Elixir wrapper around brod, the Erlang Kafka client, that supports encrypted connections to Heroku Kafka out of the box.",
      name: "Kaffe",
      source_url: "https://github.com/spreedly/kaffe",
@@ -16,7 +16,8 @@ defmodule Kaffe.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :brod]]
+    [applications: [:logger, :brod],
+     mod: {Kaffe, []}]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/support/test_brod.ex
+++ b/test/support/test_brod.ex
@@ -3,12 +3,15 @@ defmodule TestBrod do
 
   @test_partition_count Application.get_env(:kaffe, :test_partition_count)
 
+  require Logger
+
   def start_client(_endpoints, _client_name, _producer_config) do
     GenServer.start_link(__MODULE__, :ok, name: TestBrod)
+    :ok
   end
 
   def start_link_group_subscriber(_client, _consumer_group, _topics, _group_config, _consumer_config, _handler, _init_args) do
-    GenServer.start_link(__MODULE__, :ok)
+    {:ok, Process.whereis(TestBrod)}
   end
 
   def produce_sync(_client, topic, partition, key, value) do
@@ -32,4 +35,5 @@ defmodule TestBrod do
   def handle_call({:set_produce_response, response}, _from, state) do
     {:reply, response, %{state | produce_response: response}}
   end
+
 end


### PR DESCRIPTION
Batch production is supported with either the `:md5`, `:random` or function-based partitioning strategies. The messages passed to `produce_sync` do not need to be for the same partition. The producer will apply the partitioning algorithm to each message, grouping the messages by partition, before producing each batch.

This PR would eliminate the `GenServer` usage in `Kaffe.Producer` in favor of delegating to Brod for any required state (e.g., the number of partitions in a topic), which removes a key bottleneck.

This does mean that the `:round_robin` partition strategy would no longer be supported, as it requires remembering the previous partition used for each topic.

Previously, the producer was added as a worker to the caller's supervision tree, which started the producer client in Brod. Since the producer is no longer a `GenServer`, the client is now started if there is a producer configuration provided to Kaffe.