### PR TITLE
Support different worker allocation strategies

### DIFF
--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -14,6 +14,7 @@ defmodule Kaffe.Config.Consumer do
       subscriber_retries: subscriber_retries(),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(),
       offset_reset_policy: offset_reset_policy(),
+      worker_allocation_strategy: worker_allocation_strategy(),
     }
   end
 
@@ -79,6 +80,10 @@ defmodule Kaffe.Config.Consumer do
 
   def offset_reset_policy do
     config_get(:offset_reset_policy, :reset_by_subscriber)
+  end
+
+  def worker_allocation_strategy do
+    config_get(:worker_allocation_strategy, :worker_per_partition)
   end
 
   def maybe_heroku_kafka_ssl do

--- a/lib/kaffe/group_member/manager/group_manager.ex
+++ b/lib/kaffe/group_member/manager/group_manager.ex
@@ -69,7 +69,7 @@ defmodule Kaffe.GroupManager do
   end
 
   defp name do
-    :"group_manager_#{subscriber_name()}"
+    :"kaffe_group_manager_#{subscriber_name()}"
   end
 
   defp subscriber_name do

--- a/lib/kaffe/group_member/manager/group_member_supervisor.ex
+++ b/lib/kaffe/group_member/manager/group_member_supervisor.ex
@@ -34,7 +34,7 @@ defmodule Kaffe.GroupMemberSupervisor do
   end
 
   defp name do
-    :"group_member_supervisor_#{subscriber_name()}"
+    :"kaffe_group_member_supervisor_#{subscriber_name()}"
   end
 
   defp subscriber_name do

--- a/lib/kaffe/group_member/subscriber/group_member.ex
+++ b/lib/kaffe/group_member/subscriber/group_member.ex
@@ -109,7 +109,7 @@ defmodule Kaffe.GroupMember do
       Logger.debug "Allocating subscriber for assignment: #{inspect assignment}"
       {:brod_received_assignment, topic, partition, offset} = assignment
 
-      worker_pid = worker_manager().worker_for(state.worker_manager_pid, partition)
+      worker_pid = worker_manager().worker_for(state.worker_manager_pid, topic, partition)
 
       {:ok, pid} = subscriber().subscribe(
         state.subscriber_name,
@@ -164,7 +164,7 @@ defmodule Kaffe.GroupMember do
   end
 
   defp name(subscriber_name, topic) do
-    :"group_member_#{subscriber_name}_#{topic}"
+    :"kaffe_group_member_#{subscriber_name}_#{topic}"
   end
 
 end

--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -168,7 +168,7 @@ defmodule Kaffe.Subscriber do
   end
 
   defp name(subscriber_name, topic, partition) do
-    :"subscriber_#{subscriber_name}_#{topic}_#{partition}"
+    :"kaffe_subscriber_#{subscriber_name}_#{topic}_#{partition}"
   end
 
 end

--- a/lib/kaffe/group_member/worker/worker_manager.ex
+++ b/lib/kaffe/group_member/worker/worker_manager.ex
@@ -1,16 +1,25 @@
 defmodule Kaffe.WorkerManager do
   @moduledoc """
-  Manage partition-to-worker assignments. Subscribers get workers from here.
+  Manage topic/partition-to-worker assignments. Subscribers get workers
+  from here.
 
   This process manages the workers, while delegating to
   `Kaffe.WorkerSupervisor` to start each worker under supervision.
 
-  The table of workers is stored in an ETS table, `:workers`.
+  Workers are allocated based on a configured strategy
+  (`worker_allocation_strategy` in the `consumer` config): either one
+  worker per topic/partition, or one worker for a partition across
+  topics.
+
+  The first strategy is useful for higher throughput and increased
+  flexibility. The second is useful when mutliple input topics may have
+  the same messages (identified by key) and those messages must be
+  processsed sequentially.
+
+  The table of workers is stored in an ETS table, `:kaffe_workers`.
   """
   
   use GenServer
-
-  alias Kaffe.WorkerSupervisor
 
   require Logger
 
@@ -18,8 +27,8 @@ defmodule Kaffe.WorkerManager do
     GenServer.start_link(__MODULE__, [self(), subscriber_name], name: name(subscriber_name))
   end
 
-  def worker_for(pid, partition) do
-    GenServer.call(pid, {:worker_for, partition})
+  def worker_for(pid, topic, partition) do
+    GenServer.call(pid, {:worker_for, topic, partition})
   end
 
   ## Callbacks
@@ -27,41 +36,57 @@ defmodule Kaffe.WorkerManager do
   def init([supervisor_pid, subscriber_name]) do
     Logger.info "event#starting=#{__MODULE__} subscriber_name=#{subscriber_name} supervisor=#{inspect supervisor_pid}"
 
-    worker_table = :ets.new(:workers, [:set, :protected])
+    worker_table = :ets.new(:kaffe_workers, [:set, :protected])
 
     {:ok, %{supervisor_pid: supervisor_pid, subscriber_name: subscriber_name, worker_table: worker_table}}
   end
   
-  def handle_call({:worker_for, partition}, _from, state) do
-    worker_pid = allocate_worker(partition, state)
+  def handle_call({:worker_for, topic, partition}, _from, state) do
+    Logger.debug "Allocating worker: #{topic} / #{partition}"
+    worker_pid = allocate_worker(topic, partition, state)
     {:reply, worker_pid, state}
   end
 
   ## Private
 
-  defp allocate_worker(partition, %{worker_table: worker_table} = state) do
-    case :ets.lookup(worker_table, partition) do
-      [{^partition, worker_pid}] -> worker_pid
-      [] -> start_worker(partition, state)
+  defp allocate_worker(topic, partition, %{worker_table: worker_table} = state) do
+    worker_name = worker_name(topic, partition)
+    case :ets.lookup(worker_table, worker_name) do
+      [{^worker_name, worker_pid}] -> worker_pid
+      [] -> start_worker(worker_name, state)
     end
   end
 
-  defp start_worker(partition, state) do
+  defp start_worker(worker_name, state) do
     config = Kaffe.Config.Consumer.configuration
-    Logger.debug "Creating worker for partition: #{partition}"
-    WorkerSupervisor.start_worker(state.supervisor_pid, config.message_handler,
-      state.subscriber_name, partition)
-    |> capture_worker(partition, state)
+    Logger.debug "Creating worker: #{worker_name}"
+    worker_supervisor().start_worker(state.supervisor_pid, config.message_handler,
+      state.subscriber_name, worker_name)
+    |> capture_worker(worker_name, state)
   end
 
-  defp capture_worker({:ok, pid}, partition, %{worker_table: worker_table}) do
-    Logger.debug "Captured new worker: #{inspect pid} for partition: #{partition}"
-    true = :ets.insert(worker_table, {partition, pid})
+  defp capture_worker({:ok, pid}, worker_name, %{worker_table: worker_table}) do
+    true = :ets.insert(worker_table, {worker_name, pid})
     pid
   end
 
+  def worker_name(topic, partition) do
+    case worker_allocation_strategy() do
+      :worker_per_partition -> :"worker_#{partition}"
+      :worker_per_topic_partition -> :"worker_#{topic}_#{partition}"
+    end
+  end
+  
+  defp worker_allocation_strategy do
+    Kaffe.Config.Consumer.configuration.worker_allocation_strategy
+  end
+
+  defp worker_supervisor do
+    Application.get_env(:kaffe, :worker_supervisor_mod, Kaffe.WorkerSupervisor)
+  end
+
   defp name(subscriber_name) do
-    :"worker_manager_#{subscriber_name}"
+    :"kaffe_worker_manager_#{subscriber_name}"
   end
 
 end

--- a/lib/kaffe/group_member/worker/worker_supervisor.ex
+++ b/lib/kaffe/group_member/worker/worker_supervisor.ex
@@ -15,11 +15,11 @@ defmodule Kaffe.WorkerSupervisor do
     Supervisor.start_child(pid, worker(Kaffe.WorkerManager, [subscriber_name]))
   end
 
-  def start_worker(pid, message_handler, subscriber_name, partition) do
-    Logger.debug "Starting worker for partition: #{partition}"
+  def start_worker(pid, message_handler, subscriber_name, worker_name) do
+    Logger.debug "Starting worker: #{worker_name}"
     Supervisor.start_child(pid,
-      worker(Kaffe.Worker, [message_handler, subscriber_name, partition],
-        id: :"worker_#{subscriber_name}_#{partition}"))
+      worker(Kaffe.Worker, [message_handler, subscriber_name, worker_name],
+        id: :"worker_#{subscriber_name}_#{worker_name}"))
   end
 
   def init(subscriber_name) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Kaffe.Mixfile do
 
   def project do
     [app: :kaffe,
-     version: "1.1.0",
+     version: "1.2.0",
      description: "An opinionated Elixir wrapper around brod, the Erlang Kafka client, that supports encrypted connections to Heroku Kafka out of the box.",
      name: "Kaffe",
      source_url: "https://github.com/spreedly/kaffe",

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -31,7 +31,8 @@ defmodule Kaffe.Config.ConsumerTest do
         max_bytes: 10_000,
         subscriber_retries: 1,
         subscriber_retry_delay_ms: 5,
-        offset_reset_policy: :reset_by_subscriber
+        offset_reset_policy: :reset_by_subscriber,
+        worker_allocation_strategy: :worker_per_partition
       }
 
       assert Kaffe.Config.Consumer.configuration == expected

--- a/test/kaffe/group_member/subscriber/group_member_test.exs
+++ b/test/kaffe/group_member/subscriber/group_member_test.exs
@@ -19,7 +19,7 @@ defmodule Kaffe.GroupMemberTest do
   end
 
   defmodule TestWorkerManager do
-    def worker_for(_pid, _partition) do
+    def worker_for(_pid, _topic, _partition) do
       send :test_case, {:worker_for}
       {:ok, self()}
     end

--- a/test/kaffe/group_member/worker/worker_manager_test.exs
+++ b/test/kaffe/group_member/worker/worker_manager_test.exs
@@ -1,0 +1,45 @@
+defmodule Kaffe.WorkerManagerTest do
+  use ExUnit.Case
+
+  alias Kaffe.WorkerManager
+
+  defmodule TestWorkerSupervisor do
+    def start_worker(_, _, _, worker_name) do
+      case worker_name do
+        :"kaffe_worker_0" -> {:ok, 1}
+        :"kaffe_worker_topic1_0" -> {:ok, 1}
+        :"kaffe_worker_topic2_0" -> {:ok, 2}
+      end
+    end
+  end
+
+  setup do
+    Application.put_env(:kaffe, :worker_supervisor_mod, TestWorkerSupervisor)
+    {:ok, worker_manager_pid} = WorkerManager.start_link("worker_test")
+    %{worker_manager_pid: worker_manager_pid}
+  end
+
+  test "allocate worker per partition", %{worker_manager_pid: worker_manager_pid} do
+    configure_strategy(:worker_per_partition)
+
+    worker_pid1 = WorkerManager.worker_for(worker_manager_pid, "topic1", 0)
+    worker_pid2 = WorkerManager.worker_for(worker_manager_pid, "topic2", 0)
+
+    assert worker_pid1 == worker_pid2
+  end
+
+  test "allocate worker per topic partition", %{worker_manager_pid: worker_manager_pid} do
+    configure_strategy(:worker_per_topic_partition)
+
+    worker_pid1 = WorkerManager.worker_for(worker_manager_pid, "topic1", 0)
+    worker_pid2 = WorkerManager.worker_for(worker_manager_pid, "topic2", 0)
+
+    refute worker_pid1 == worker_pid2
+  end
+
+  defp configure_strategy(strategy) do
+    consumer_config = Application.get_env(:kaffe, :consumer)
+    Application.put_env(:kaffe, :consumer,
+        Keyword.put(consumer_config, :worker_allocation_strategy, strategy))
+  end
+end


### PR DESCRIPTION
See the referenced issue for a discussion and reasoning behind the strategies.

The strategies are supported by variations in the worker name.

Currently, two strategies are supported:
- `:worker_per_partition`
- `:worker_per_topic_partition`

The `:worker_per_partition` strategy is the default and was the only strategy previously supported by Kaffe. It allocates a worker per partition number across all topics. This means that partition `0` from two topics are funneled through the same worker.

The newly supported strategy is `:worker_per_topic_partition`. It allocates a worker per topic/partition combination. This allows messages to be read from the same partition in different topics concurrently.

The use of a single worker per partition across topics (`:worker_per_partition`) is intended to prevent key collisions when reading the same keys from a real time and batch topic simultaneously.

However, a collision in this configuration is not very likely.

Conversely, being able to read from the same partition across topics simultaneously provides for better throughput and prevents topic/partition starvation when a batch of messages take a long time.

I think `:worker_per_topic_partition` should be the preferred strategy for most consumers. I left `:worker_per_partition` as the default for backward compatibility (in the 1.x line). Maybe a 2.x Kaffe would change the default. Consumers reading a lot of messages from multiple topics should have a throughput increase with the `:worker_per_topic_partition`.

This version is designated as 1.2.0.

ENSI-224