### PR TITLE
Don't log produced messages, since it's extremely expensive

### DIFF
--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -37,7 +37,7 @@ defmodule Kaffe.Producer do
   `messages` must be a list of `{key, value}` tuples
 
   Returns:
-  
+
        * `:ok` on successfully producing each message
        * `{:error, reason}` for any error
   """
@@ -52,7 +52,7 @@ defmodule Kaffe.Producer do
   for production and don't want to specify the topic for each call.
 
   Returns:
-  
+
        * `:ok` on successfully producing the message
        * `{:error, reason}` for any error
   """
@@ -122,7 +122,7 @@ defmodule Kaffe.Producer do
   defp produce_list_to_topic(message_list, topic) do
     message_list
     |> Enum.reduce_while(:ok, fn ({partition, messages}, :ok) ->
-      Logger.debug "event#produce_list_to_topic partition=#{partition} messages=#{inspect messages}"
+      Logger.debug "event#produce_list_to_topic topic=#{topic} partition=#{partition}"
       case @kafka.produce_sync(client_name(), topic, partition, "ignored", messages) do
         :ok -> {:cont, :ok}
         {:error, _reason} = error -> {:halt, error}


### PR DESCRIPTION
Hi there,

We've been attempting to use this library, but experimentation revealed that the batch produce was significantly slower than alternatives (like `kafka_ex`). With a bit of profiling using `exprof`, we tracked it down to the log line below, which inspects a large number of messages. Here's the relevant lines of the profile:

```
...
'Elixir.String':'printable?'/1                                   2880097    37.01   447204  [      0.16]
'Elixir.Inspect.BitString':escape/3                              2880097    55.29   668059  [      0.23]
---------------------------------------------------------------  -------  -------  -------  [----------]
Total:                                                           5776733  100.00%  1208305  [      0.21]
```

As you can see, 93% of the time was spent doing string-wrangling. Removing the log line altogether and re-profiling improved the call time by 1000x.

I'm aware that you should be able to make these log lines disappear entirely using `:compile_time_purge_level`. After a few unsuccessful attempts at this, I gave up. I think you can make the argument that many people will not know to do this anyway.

I also tried passing a function to `Logger#debug` in an attempt to make the string evaluation happen lazily. This also did not work (note that we're on 1.4.1, and the docs do not make mention of this lazy behaviour until 1.5.0).

Finally, I just decided to remove the message logging from the line altogether. This worked as expected (the string-wrangling in the profile disappeared). This seems like an acceptable solution - I'm not sure there's value in logging a batch of produced messages, and the lib doesn't log the message when it produces a single message anyway.

Let me know if I should be solving this a different way. Thanks!