### PR TITLE
add state to the group consumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ erl_crash.dump
 
 /priv
 .tool-versions
+
+.idea/
+

--- a/test/kaffe/group_member/worker/worker_test.exs
+++ b/test/kaffe/group_member/worker/worker_test.exs
@@ -11,9 +11,10 @@ defmodule Kaffe.WorkerTest do
   end
   
   defmodule TestHandler do
-    def handle_messages(messages) do
+    def init_handler(), do: {:ok, :some_state}
+    def handle_messages(messages, state) do
       send :test_case, {:handle_messages, messages}
-      :ok
+      {:ok, state}
     end
   end
 


### PR DESCRIPTION
I need that for work. I've added an init_handler() function to define a state, which is passed around when handle_messages() is called. Of course it's not backward compatible so this should be reworked so that it's a new mode of consuming, instead of replacing the existing one. But I thouhgt I'd push that here now so I can get feedback.

Let me know if there is already a way to have a state being passed around, that I missed.

Thanks