### PR TITLE
allow to ack a given offset, or to do no ack at all

### DIFF
--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -46,8 +46,8 @@ defmodule Kaffe.Subscriber do
     GenServer.stop(subscriber_pid)
   end
 
-  def ack_messages(subscriber_pid, topic, partition, generation_id, offset) do
-    GenServer.cast(subscriber_pid, {:ack_messages, topic, partition, generation_id, offset})
+  def ack_messages(subscriber_pid, topic, partition, generation_id, offset, ack? \\ true) do
+    GenServer.cast(subscriber_pid, {:ack_messages, topic, partition, generation_id, offset, ack?})
   end
 
   def init([subscriber_name, group_coordinator_pid, worker_pid,
@@ -100,7 +100,7 @@ defmodule Kaffe.Subscriber do
     {:noreply, state}
   end
 
-  def handle_cast({:ack_messages, topic, partition, generation_id, offset}, state) do
+  def handle_cast({:ack_messages, topic, partition, generation_id, offset, ack?}, state) do
 
     Logger.debug "Ready to ack messages of #{state.topic} / #{state.partition} / #{generation_id} at offset: #{offset}"
 
@@ -110,8 +110,10 @@ defmodule Kaffe.Subscriber do
     ^generation_id = state.gen_id
 
     # Update the offsets in the group
-    :ok = group_coordinator().ack(state.group_coordinator_pid, state.gen_id,
+    if ack? do
+      :ok = group_coordinator().ack(state.group_coordinator_pid, state.gen_id,
         state.topic, state.partition, offset)
+    end
     # Request more messages from the consumer
     :ok = kafka().consume_ack(state.subscriber_pid, offset)
 

--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -102,7 +102,7 @@ defmodule Kaffe.Subscriber do
 
   def handle_cast({:ack_messages, topic, partition, generation_id, offset, ack?}, state) do
 
-    Logger.debug "Ready to ack messages of #{state.topic} / #{state.partition} / #{generation_id} at offset: #{offset}"
+    Logger.debug "Ready to ack messages of #{state.topic} / #{state.partition} / #{generation_id} / #{ack?} at offset: #{offset}"
 
     # Is this the ack we're looking for?
     ^topic = state.topic

--- a/lib/kaffe/group_member/worker/worker.ex
+++ b/lib/kaffe/group_member/worker/worker.ex
@@ -35,7 +35,8 @@ defmodule Kaffe.Worker do
         offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
         subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
       {:ok, :no_ack} ->
-        subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, -1, false)
+        offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
+        subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset, false)
       {:ok, offset} ->
         subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
     end

--- a/lib/kaffe/group_member/worker/worker.ex
+++ b/lib/kaffe/group_member/worker/worker.ex
@@ -34,7 +34,8 @@ defmodule Kaffe.Worker do
       :ok ->
         offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
         subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
-      {:ok, :no_ack} -> :ok
+      {:ok, :no_ack} ->
+        subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, -1, false)
       {:ok, offset} ->
         subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
     end

--- a/lib/kaffe/group_member/worker/worker.ex
+++ b/lib/kaffe/group_member/worker/worker.ex
@@ -30,9 +30,15 @@ defmodule Kaffe.Worker do
   def handle_cast({:process_messages, subscriber_pid, topic, partition, generation_id, messages},
       %{message_handler: message_handler} = state) do
 
-    :ok = apply(message_handler, :handle_messages, [messages])
-    offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
-    subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
+    case apply(message_handler, :handle_messages, [messages]) do
+      :ok ->
+        offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
+        subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
+      {:ok, offset} ->
+        subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
+      {:ok, :no_ack} -> :ok
+    end
+
 
     {:noreply, state}
   end

--- a/lib/kaffe/group_member/worker/worker.ex
+++ b/lib/kaffe/group_member/worker/worker.ex
@@ -34,9 +34,9 @@ defmodule Kaffe.Worker do
       :ok ->
         offset = Enum.reduce(messages, 0, &max(&1.offset, &2))
         subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
+      {:ok, :no_ack} -> :ok
       {:ok, offset} ->
         subscriber().ack_messages(subscriber_pid, topic, partition, generation_id, offset)
-      {:ok, :no_ack} -> :ok
     end
 
 

--- a/test/kaffe/group_member/worker/worker_test.exs
+++ b/test/kaffe/group_member/worker/worker_test.exs
@@ -5,8 +5,8 @@ defmodule Kaffe.WorkerTest do
   alias Kaffe.Worker
 
   defmodule TestSubscriber do
-    def ack_messages(_subscriber_pid, topic, partition, generation_id, offset) do
-      send :test_case, {:ack_messages, {topic, partition, generation_id, offset}}
+    def ack_messages(_subscriber_pid, topic, partition, generation_id, offset, ack? \\ true) do
+      send :test_case, {:ack_messages, {topic, partition, generation_id, offset, ack?}}
     end
   end
   
@@ -30,6 +30,6 @@ defmodule Kaffe.WorkerTest do
       [%{key: :one, offset: 100}, %{key: :two, offset: 101}])
 
     assert_receive {:handle_messages, [%{key: :one, offset: 100}, %{key: :two, offset: 101}]}
-    assert_receive {:ack_messages, {"topic", 1, 2, 101}}
+    assert_receive {:ack_messages, {"topic", 1, 2, 101, true}}
   end
 end


### PR DESCRIPTION
I have not added tests nor doc yet, first I wante to see if that's of any interest for you. When using kaffe, I need to not always acknowledge the message I just consumed, but acknowledge them after a while if other thongs went well. Instead of providing a ack() function like in the simple consumer, I provide the ability to automatically ack (as before), or ack a given offset, or not ack yet.

let me know what you think
 