### PR TITLE
Send a Kafka timestamp with each message

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ It's possible that your topic and system are entirely ok with losing some messag
 
 ## Kaffe Producer Usage
 
-`Kaffe.Producer` handles producing messages to Kafka and will automatically select the topic partitions per message or can be given a function to call to determine the partition per message.
+`Kaffe.Producer` handles producing messages to Kafka and will automatically select the topic partitions per message or can be given a function to call to determine the partition per message. Kaffe automatically inserts a Kafka timestamp with each message.
 
 Configure your Kaffe Producer in your mix config
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Kaffe.Mixfile do
 
   def project do
     [app: :kaffe,
-     version: "1.5.0",
+     version: "1.6.0",
      description: "An opinionated Elixir wrapper around brod, the Erlang Kafka client, that supports encrypted connections to Heroku Kafka out of the box.",
      name: "Kaffe",
      source_url: "https://github.com/spreedly/kaffe",

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -20,7 +20,8 @@ defmodule Kaffe.ProducerTest do
 
     test "(topic, message_list) produces a list of messages to the specific topic" do
       :ok = Producer.produce_sync("topic2", [{"key8", "value1"}, {"key12", "value2"}])
-      assert_receive [:produce_sync, "topic2", 17, "ignored", [{"key8", "value1"}, {"key12", "value2"}]]
+      assert_receive [:produce_sync, "topic2", 17, "ignored",
+        [{_ts1, "key8", "value1"}, {_ts2, "key12", "value2"}]]
     end
 
     test "(topic, key, value) produces a message to the specific topic" do
@@ -37,7 +38,8 @@ defmodule Kaffe.ProducerTest do
     test "(topic, partition, key, message_list) produces a list of messages to the specific topic/parition" do
       partition = 99
       :ok = Producer.produce_sync("topic2", partition, [{"key8", "value1"}, {"key12", "value2"}])
-      assert_receive [:produce_sync, "topic2", ^partition, "ignored", [{"key8", "value1"}, {"key12", "value2"}]]
+      assert_receive [:produce_sync, "topic2", ^partition, "ignored",
+        [{_ts1, "key8", "value1"}, {_ts2, "key12", "value2"}]]
     end
 
     test "passes through the result" do
@@ -113,7 +115,6 @@ defmodule Kaffe.ProducerTest do
       assert_receive [:produce_sync, "topic", 0, "key", "value"]
     end
   end
-
 
   defp update_producer_config(key, value) do
     producer_config = Application.get_env(:kaffe, :producer)


### PR DESCRIPTION
This uses the new Brod support for embedding a Kafka timestamp. The timestamp value is computed for each message as it is produced.

Added a bit in the README about the timestamp.

ENDS-329