### PR TITLE
Fix incorrect subscriber function declaration

### DIFF
--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -46,8 +46,8 @@ defmodule Kaffe.Subscriber do
     GenServer.stop(subscriber_pid)
   end
 
-  def commit_offset(subscriber_pid, topic, partition, generation_id, offset) do
-    GenServer.cast(subscriber_pid, {:commit_offset, topic, partition, generation_id, offset})
+  def commit_offsets(subscriber_pid, topic, partition, generation_id, offset) do
+    GenServer.cast(subscriber_pid, {:commit_offsets, topic, partition, generation_id, offset})
   end
 
   def request_more_messages(subscriber_pid, offset) do
@@ -104,7 +104,7 @@ defmodule Kaffe.Subscriber do
     {:noreply, state}
   end
 
-  def handle_cast({:commit_offset, topic, partition, generation_id, offset}, state) do
+  def handle_cast({:commit_offsets, topic, partition, generation_id, offset}, state) do
     Logger.debug "Ready to commit offsets for #{state.topic} / #{state.partition} / #{generation_id} at offset: #{offset}"
 
     # Is this the ack we're looking for?


### PR DESCRIPTION
Unfortunately the subscriber had a slightly incorrect function name
of commit_offset/5 instead of commit_offsets/5 (missing an "s" and
the end) and the worker was calling commit_offsets/5 which didn't exist
causing it to crash when a message handler intended for offsets to be
committed back to Kafka.

Moreover, the tests did not catch this since the modules injected during
the tests in place of the real subscriber had defined the function name
properly.