### PR TITLE
Brod options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Batch message consumers receive a list of messages and work as part of the `:bro
       with 32 partitions, there is the potential of 64MB in buffered
       messages at any one time.
 
+      `:min_bytes` Sets a minimum threshold for the number of
+       bytes to fetch for a batch of messages. The default is 0MB.
+
+      `:max_wait_time` Sets the maximum number of milliseconds that the
+      broker is allowed to collect min_bytes of messages in a batch of messages
+
       `:offset_reset_policy` controls how the subscriber handles an
       expired offset. See the Kafka consumer option,
       [`auto.offset.reset`](https://kafka.apache.org/documentation/#newconsumerconfigs).

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -11,6 +11,8 @@ defmodule Kaffe.Config.Consumer do
       async_message_ack: async_message_ack(),
       rebalance_delay_ms: rebalance_delay_ms(),
       max_bytes: max_bytes(),
+      min_bytes: min_bytes(),
+      max_wait_time: max_wait_time(),
       subscriber_retries: subscriber_retries(),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(),
       offset_reset_policy: offset_reset_policy(),
@@ -48,6 +50,14 @@ defmodule Kaffe.Config.Consumer do
 
   def max_bytes do
    config_get(:max_bytes, 1_000_000)
+  end
+
+  def min_bytes do
+   config_get(:min_bytes, 0)
+  end
+
+  def max_wait_time do
+   config_get(:max_wait_time, 10_000)
   end
 
   def subscriber_retries do

--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -13,6 +13,9 @@ defmodule Kaffe.Subscriber do
   The subscriber reads the following options out of the configuration:
 
       - `max_bytes` - The maximum number of message bytes to receive in a batch
+      - `min_bytes` - The minimum number of message bytes to receive in a batch
+      - `max_wait_time` - Maximum number of milliseconds broker will wait for `:min_bytes` of messages
+          to be collected
       - `offset_reset_policy` - The native `auto.offset.reset` option,
           either `:reset_to_earliest` or `:reset_to_latest`.
 
@@ -164,6 +167,8 @@ defmodule Kaffe.Subscriber do
 
   defp subscriber_ops do
     [max_bytes: Kaffe.Config.Consumer.configuration.max_bytes,
+     min_bytes: Kaffe.Config.Consumer.configuration.min_bytes,
+     max_wait_time: Kaffe.Config.Consumer.configuration.max_wait_time,
      offset_reset_policy: Kaffe.Config.Consumer.configuration.offset_reset_policy]
   end
 

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -29,6 +29,8 @@ defmodule Kaffe.Config.ConsumerTest do
         async_message_ack: false,
         rebalance_delay_ms: 100,
         max_bytes: 10_000,
+        min_bytes: 0,
+        max_wait_time: 10_000,
         subscriber_retries: 1,
         subscriber_retry_delay_ms: 5,
         offset_reset_policy: :reset_by_subscriber,


### PR DESCRIPTION
Adds the `min_bytes` and `max_wait_time` brod options to the Kafka consumer