### PR TITLE
Add start_link/1 function to GroupMemberSupervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,17 @@ Batch message consumers receive a list of messages and work as part of the `:bro
   3. Add `Kaffe.GroupMemberSupervisor` as a supervisor in your
      supervision tree
 
-       ```elixir
-       supervisor(Kaffe.GroupMemberSupervisor, [])
-       ```
+      ```elixir
+      def start(_type, _args) do
+
+        children = [
+          Kaffe.GroupMemberSupervisor
+        ]
+
+        opts = [strategy: :one_for_all, name: MyApp.Supervisor]
+        Supervisor.start_link(children, opts)
+      end
+      ```
 
 ### async message acknowledgement
 

--- a/lib/kaffe/group_member/manager/group_member_supervisor.ex
+++ b/lib/kaffe/group_member/manager/group_member_supervisor.ex
@@ -7,6 +7,10 @@ defmodule Kaffe.GroupMemberSupervisor do
 
   require Logger
 
+  def start_link(_) do
+    start_link()
+  end
+
   def start_link do
     Supervisor.start_link(__MODULE__, :ok, name: name())
   end

--- a/lib/kaffe/group_member/subscriber/subscriber.ex
+++ b/lib/kaffe/group_member/subscriber/subscriber.ex
@@ -108,7 +108,7 @@ defmodule Kaffe.Subscriber do
   end
 
   def handle_cast({:commit_offsets, topic, partition, generation_id, offset}, state) do
-    Logger.debug "Ready to commit offsets for #{state.topic} / #{state.partition} / #{generation_id} at offset: #{offset}"
+    Logger.debug "Committing offsets for #{state.topic} / #{state.partition} / #{generation_id} at offset: #{offset}"
 
     # Is this the ack we're looking for?
     ^topic = state.topic
@@ -123,7 +123,7 @@ defmodule Kaffe.Subscriber do
   end
 
   def handle_cast({:request_more_messages, offset}, state) do
-    Logger.debug "Ready to consume more messages of #{state.topic} / #{state.partition} at offset: #{offset}. Offset has not been commited back"
+    Logger.debug "Requesting messages from #{state.topic} / #{state.partition} at offset: #{offset}"
 
     :ok = kafka().consume_ack(state.subscriber_pid, offset)
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Kaffe.Mixfile do
 
   def project do
     [app: :kaffe,
-     version: "1.7.0",
+     version: "1.8.0",
      description: "An opinionated Elixir wrapper around brod, the Erlang Kafka client, that supports encrypted connections to Heroku Kafka out of the box.",
      name: "Kaffe",
      source_url: "https://github.com/spreedly/kaffe",


### PR DESCRIPTION
This function is in support for the new supervisor child specs supported
in Elixir. This allows just the module to be provided as a child to the
parent supervisor.

```
  def start(_type, _args) do

    children = [
      Kaffe.GroupMemberSupervisor
    ]

    opts = [strategy: :one_for_all, name: MyApp.Supervisor]
    Supervisor.start_link(children, opts)
  end
```