### PR TITLE
Bound Brod dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Kaffe.Mixfile do
   def project do
     [
       app: :kaffe,
-      version: "1.9.0",
+      version: "1.9.1",
       description:
         "An opinionated Elixir wrapper around brod, the Erlang Kafka client, that supports encrypted connections to Heroku Kafka out of the box.",
       name: "Kaffe",
@@ -27,8 +27,8 @@ defmodule Kaffe.Mixfile do
 
   defp deps do
     [
-      {:brod, "~> 3.0"},
-      {:ex_doc, "~> 0.14", only: :dev, runtime: false}
+      {:brod, ">= 3.0.0 and < 3.5.0"},
+      {:ex_doc, "~> 0.14", only: :dev, runtime: false},
     ]
   end
 
@@ -36,7 +36,7 @@ defmodule Kaffe.Mixfile do
     [
       name: :kaffe,
       licenses: ["MIT License"],
-      maintainers: ["Stephen Ball", "Kevin Lewis", "Ryan Daigle", "Spreedly"],
+      maintainers: ["Kevin Lewis", "David Santoso", "Ryan Daigle", "Spreedly"],
       links: %{"GitHub" => "https://github.com/spreedly/kaffe"}
     ]
   end


### PR DESCRIPTION
Kaffe requires a Brod version between 3.0 and 3.4.

cc: @jdewar

Fixes #75