### PR TITLE
allow to set endpoints config in string format

### DIFF
--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -2,11 +2,13 @@ defmodule Kaffe.Config do
   def heroku_kafka_endpoints do
     "KAFKA_URL"
     |> System.get_env()
-    |> heroku_kafka_endpoints
+    |> parse_endpoints()
   end
 
-  def heroku_kafka_endpoints(kafka_url) do
-    kafka_url
+  def parse_endpoints(endpoints) when is_list(endpoints), do: endpoints
+
+  def parse_endpoints(url) when is_binary(url) do
+    url
     |> String.replace("kafka+ssl://", "")
     |> String.replace("kafka://", "")
     |> String.split(",")
@@ -69,20 +71,5 @@ defmodule Kaffe.Config do
   def extract_type_and_der(cert_key) do
     {type, der_cert, _} = decode_pem(cert_key)
     {type, der_cert}
-  end
-
-  def parse_endpoints(endpoints) when is_list(endpoints), do: endpoints
-
-  def parse_endpoints(endpoints) when is_binary(endpoints) do
-    endpoints
-    |> String.split(",")
-    |> Enum.map(fn endpoint ->
-      {hostname, port} =
-        endpoint
-        |> String.split(":")
-        |> List.to_tuple()
-
-      {String.to_atom(hostname), String.to_integer(port)}
-    end)
   end
 end

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -70,4 +70,19 @@ defmodule Kaffe.Config do
     {type, der_cert, _} = decode_pem(cert_key)
     {type, der_cert}
   end
+
+  def parse_endpoints(endpoints) when is_list(endpoints), do: endpoints
+
+  def parse_endpoints(endpoints) when is_binary(endpoints) do
+    endpoints
+    |> String.split(",")
+    |> Enum.map(fn endpoint ->
+      {hostname, port} =
+        endpoint
+        |> String.split(":")
+        |> List.to_tuple()
+
+      {String.to_atom(hostname), String.to_integer(port)}
+    end)
+  end
 end

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -1,4 +1,6 @@
 defmodule Kaffe.Config.Consumer do
+  import Kaffe.Config, only: [parse_endpoints: 1]
+
   def configuration do
     %{
       endpoints: endpoints(),
@@ -33,7 +35,7 @@ defmodule Kaffe.Config.Consumer do
   def endpoints do
     case heroku_kafka?() do
       true -> Kaffe.Config.heroku_kafka_endpoints()
-      false -> config_get!(:endpoints)
+      false -> parse_endpoints(config_get!(:endpoints))
     end
   end
 

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -1,5 +1,5 @@
 defmodule Kaffe.Config.Consumer do
-  import Kaffe.Config, only: [parse_endpoints: 1]
+  import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
   def configuration do
     %{
@@ -33,7 +33,11 @@ defmodule Kaffe.Config.Consumer do
   def async_message_ack, do: config_get(:async_message_ack, false)
 
   def endpoints do
-    parse_endpoints(config_get!(:endpoints))
+    if heroku_kafka?() do
+      heroku_kafka_endpoints()
+    else
+      parse_endpoints(config_get!(:endpoints))
+    end
   end
 
   def consumer_group_config do

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -33,10 +33,7 @@ defmodule Kaffe.Config.Consumer do
   def async_message_ack, do: config_get(:async_message_ack, false)
 
   def endpoints do
-    case heroku_kafka?() do
-      true -> Kaffe.Config.heroku_kafka_endpoints()
-      false -> parse_endpoints(config_get!(:endpoints))
-    end
+    parse_endpoints(config_get!(:endpoints))
   end
 
   def consumer_group_config do

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -1,4 +1,6 @@
 defmodule Kaffe.Config.Producer do
+  import Kaffe.Config, only: [parse_endpoints: 1]
+
   def configuration do
     %{
       endpoints: endpoints(),
@@ -14,7 +16,7 @@ defmodule Kaffe.Config.Producer do
   def endpoints do
     case heroku_kafka?() do
       true -> Kaffe.Config.heroku_kafka_endpoints()
-      false -> config_get!(:endpoints)
+      false -> parse_endpoints(config_get!(:endpoints))
     end
   end
 

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -14,10 +14,7 @@ defmodule Kaffe.Config.Producer do
   def producer_topics, do: config_get!(:topics)
 
   def endpoints do
-    case heroku_kafka?() do
-      true -> Kaffe.Config.heroku_kafka_endpoints()
-      false -> parse_endpoints(config_get!(:endpoints))
-    end
+    parse_endpoints(config_get!(:endpoints))
   end
 
   def client_producer_config do

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -1,5 +1,5 @@
 defmodule Kaffe.Config.Producer do
-  import Kaffe.Config, only: [parse_endpoints: 1]
+  import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
   def configuration do
     %{
@@ -14,7 +14,11 @@ defmodule Kaffe.Config.Producer do
   def producer_topics, do: config_get!(:topics)
 
   def endpoints do
-    parse_endpoints(config_get!(:endpoints))
+    if heroku_kafka?() do
+      heroku_kafka_endpoints()
+    else
+      parse_endpoints(config_get!(:endpoints))
+    end
   end
 
   def client_producer_config do

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -47,6 +47,44 @@ defmodule Kaffe.Config.ConsumerTest do
 
       assert Kaffe.Config.Consumer.configuration() == expected
     end
+
+    test "string endpoints parsed correctly" do
+      config = Application.get_env(:kaffe, :consumer)
+      endpoints = Keyword.get(config, :endpoints)
+      Application.put_env(:kaffe, :consumer, Keyword.put(config, :endpoints, "kafka:9092,localhost:9092"))
+
+      expected = %{
+        endpoints: [kafka: 9092, localhost: 9092],
+        subscriber_name: :"kaffe-test-group",
+        consumer_group: "kaffe-test-group",
+        topics: ["kaffe-test"],
+        group_config: [
+          offset_commit_policy: :commit_to_kafka_v2,
+          offset_commit_interval_seconds: 10
+        ],
+        consumer_config: [
+          auto_start_producers: false,
+          allow_topic_auto_creation: false,
+          begin_offset: :earliest
+        ],
+        message_handler: SilentMessage,
+        async_message_ack: false,
+        rebalance_delay_ms: 100,
+        max_bytes: 10_000,
+        min_bytes: 0,
+        max_wait_time: 10_000,
+        subscriber_retries: 1,
+        subscriber_retry_delay_ms: 5,
+        offset_reset_policy: :reset_by_subscriber,
+        worker_allocation_strategy: :worker_per_partition
+      }
+
+      on_exit(fn ->
+        Application.put_env(:kaffe, :consumer, Keyword.put(config, :endpoints, endpoints))
+      end)
+
+      assert Kaffe.Config.Consumer.configuration() == expected
+    end
   end
 
   test "correct settings with sasl plain are extracted" do

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -88,10 +88,9 @@ defmodule Kaffe.Config.ConsumerTest do
   end
 
   test "correct settings with sasl plain are extracted" do
-    sasl_config =
-      :kaffe
-      |> Application.get_env(:consumer)
-      |> Keyword.put(:sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
+    config = Application.get_env(:kaffe, :consumer)
+    sasl = Keyword.get(config, :sasl)
+    sasl_config = Keyword.put(config, :sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
 
     Application.put_env(:kaffe, :consumer, sasl_config)
 
@@ -121,6 +120,10 @@ defmodule Kaffe.Config.ConsumerTest do
       offset_reset_policy: :reset_by_subscriber,
       worker_allocation_strategy: :worker_per_partition
     }
+
+    on_exit(fn ->
+      Application.put_env(:kaffe, :consumer, Keyword.put(config, :sasl, sasl))
+    end)
 
     assert Kaffe.Config.Consumer.configuration() == expected
   end

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -36,10 +36,9 @@ defmodule Kaffe.Config.ProducerTest do
     end
 
     test "correct settings with sasl plain are extracted" do
-      sasl_config =
-        :kaffe
-        |> Application.get_env(:producer)
-        |> Keyword.put(:sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
+      config = Application.get_env(:kaffe, :producer)
+      sasl = Keyword.get(config, :sasl)
+      sasl_config = Keyword.put(config, :sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
 
       Application.put_env(:kaffe, :producer, sasl_config)
 
@@ -65,6 +64,10 @@ defmodule Kaffe.Config.ProducerTest do
         client_name: :kaffe_producer_client,
         partition_strategy: :md5
       }
+
+      on_exit(fn ->
+        Application.put_env(:kaffe, :producer, Keyword.put(config, :sasl, sasl))
+      end)
 
       assert Kaffe.Config.Producer.configuration() == expected
     end

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -69,4 +69,38 @@ defmodule Kaffe.Config.ProducerTest do
       assert Kaffe.Config.Producer.configuration() == expected
     end
   end
+
+  test "string endpoints parsed correctly" do
+    config = Application.get_env(:kaffe, :producer)
+    endpoints = Keyword.get(config, :endpoints)
+    Application.put_env(:kaffe, :producer, Keyword.put(config, :endpoints, "kafka:9092,localhost:9092"))
+
+    expected = %{
+      endpoints: [kafka: 9092, localhost: 9092],
+      producer_config: [
+        auto_start_producers: true,
+        allow_topic_auto_creation: false,
+        default_producer_config: [
+          required_acks: -1,
+          ack_timeout: 1000,
+          partition_buffer_limit: 512,
+          partition_onwire_limit: 1,
+          max_batch_size: 1_048_576,
+          max_retries: 3,
+          retry_backoff_ms: 500,
+          compression: :no_compression,
+          min_compression_batch_size: 1024
+        ]
+      ],
+      topics: ["kaffe-test"],
+      client_name: :kaffe_producer_client,
+      partition_strategy: :md5
+    }
+
+    on_exit(fn ->
+      Application.put_env(:kaffe, :producer, Keyword.put(config, :endpoints, endpoints))
+    end)
+
+    assert Kaffe.Config.Producer.configuration() == expected
+  end
 end

--- a/test/kaffe/config_test.exs
+++ b/test/kaffe/config_test.exs
@@ -2,6 +2,21 @@ defmodule Kaffe.ConfigTest do
   use ExUnit.Case, async: true
 
   describe "heroku_kafka_endpoints/1" do
+    test "transforms heroku endpoints into the correct format" do
+      System.put_env(
+        "KAFKA_URL",
+        "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
+      )
+
+      expected = [{:"192.168.1.100", 9096}, {:"192.168.1.101", 9096}, {:"192.168.1.102", 9096}]
+
+      on_exit(fn ->
+        System.delete_env("KAFKA_URL")
+      end)
+
+      assert Kaffe.Config.heroku_kafka_endpoints() == expected
+    end
+
     test "transforms endpoints into the correct format" do
       kafka_url = "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
       expected = [{:"192.168.1.100", 9096}, {:"192.168.1.101", 9096}, {:"192.168.1.102", 9096}]

--- a/test/kaffe/config_test.exs
+++ b/test/kaffe/config_test.exs
@@ -6,7 +6,7 @@ defmodule Kaffe.ConfigTest do
       kafka_url = "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
       expected = [{:"192.168.1.100", 9096}, {:"192.168.1.101", 9096}, {:"192.168.1.102", 9096}]
 
-      assert Kaffe.Config.heroku_kafka_endpoints(kafka_url) == expected
+      assert Kaffe.Config.parse_endpoints(kafka_url) == expected
     end
   end
 


### PR DESCRIPTION
E.g.: `kafka:9092,localhost:9092` which allows to get endpoints config from environment variable for both, producers and consumers
