### PR TITLE
feat: support SASL_PLAINTEXT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Batch message consumers receive a list of messages and work as part of the `:bro
 
           #optional
           sasl: %{
-            mech: :plain,
+            mechanism: :plain,
             login: System.get_env("KAFFE_PRODUCER_USER"),
             password: System.get_env("KAFFE_PRODUCER_PASSWORD")
           }
@@ -290,7 +290,7 @@ config :kaffe,
     # optional
     partition_strategy: :md5,
     sasl: %{
-      mech: :plain,
+      mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),
       password: System.get_env("KAFFE_PRODUCER_PASSWORD")
     }

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Batch message consumers receive a list of messages and work as part of the `:bro
           offset_reset_policy: :reset_to_latest,
           max_bytes: 500_000,
           worker_allocation_strategy: :worker_per_topic_partition,
+
+          #optional
+          sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
         ],
       ```
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ config :kaffe,
     topics: ["kafka-topic"],
 
     # optional
-    partition_strategy: :md5
+    partition_strategy: :md5,
+    sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
   ]
 ```
 
@@ -292,6 +293,8 @@ The `partition_strategy` setting can be one of:
 - function: a given function to call to determine the correct partition
 
 You can also set any of the Brod producer configuration options in the `producer` section - see [the Brod sources](https://github.com/klarna/brod/blob/master/src/brod_producer.erl#L90) for a list of keys and their meaning.
+
+If kafka broker configured with `SASL_PLAINTEXT` auth, `sasl` option can be added
 
 ### Heroku Configuration
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Batch message consumers receive a list of messages and work as part of the `:bro
   The module's `handle_messages/1` function _must_ return `:ok` or Kaffe will throw an error. The Kaffe consumer will block until your `handle_messages/1` function returns `:ok`.
 
   ```elixir
-  defmodule MessageProcessor
+  defmodule MessageProcessor do
     def handle_messages(messages) do
       for %{key: key, value: value} = message <- messages do
         IO.inspect message
@@ -189,7 +189,11 @@ Batch message consumers receive a list of messages and work as part of the `:bro
           worker_allocation_strategy: :worker_per_topic_partition,
 
           #optional
-          sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
+          sasl: [
+            mech: :plain,
+            login: System.get_env("KAFFE_PRODUCER_USER"),
+            password: System.get_env("KAFFE_PRODUCER_PASSWORD")
+          ]
         ],
       ```
 
@@ -285,7 +289,11 @@ config :kaffe,
 
     # optional
     partition_strategy: :md5,
-    sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
+    sasl: [
+      mech: :plain,
+      login: System.get_env("KAFFE_PRODUCER_USER"),
+      password: System.get_env("KAFFE_PRODUCER_PASSWORD")
+    ]
   ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ Batch message consumers receive a list of messages and work as part of the `:bro
           worker_allocation_strategy: :worker_per_topic_partition,
 
           #optional
-          sasl: [
+          sasl: %{
             mech: :plain,
             login: System.get_env("KAFFE_PRODUCER_USER"),
             password: System.get_env("KAFFE_PRODUCER_PASSWORD")
-          ]
+          }
         ],
       ```
 
@@ -289,11 +289,11 @@ config :kaffe,
 
     # optional
     partition_strategy: :md5,
-    sasl: [
+    sasl: %{
       mech: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),
       password: System.get_env("KAFFE_PRODUCER_PASSWORD")
-    ]
+    }
   ]
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,4 +14,4 @@ config :kaffe,
 #   metadata: [:module]
 config :logger, backends: []
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,7 @@ config :kaffe,
     subscriber_retries: 1,
     subscriber_retry_delay_ms: 5,
     sasl: %{
-      mech: :plain,
+      mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),
       password: System.get_env("KAFFE_PRODUCER_PASSWORD")
     }
@@ -26,7 +26,7 @@ config :kaffe,
     endpoints: [kafka: 9092],
     topics: ["kaffe-test"],
     sasl: %{
-      mech: :plain,
+      mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),
       password: System.get_env("KAFFE_PRODUCER_PASSWORD")
     }

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,10 +16,18 @@ config :kaffe,
     max_bytes: 10_000,
     subscriber_retries: 1,
     subscriber_retry_delay_ms: 5,
-    sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
+    sasl: %{
+      mech: :plain,
+      login: System.get_env("KAFFE_PRODUCER_USER"),
+      password: System.get_env("KAFFE_PRODUCER_PASSWORD")
+    }
   ],
   producer: [
     endpoints: [kafka: 9092],
     topics: ["kaffe-test"],
-    sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
+    sasl: %{
+      mech: :plain,
+      login: System.get_env("KAFFE_PRODUCER_USER"),
+      password: System.get_env("KAFFE_PRODUCER_PASSWORD")
+    }
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,10 +15,11 @@ config :kaffe,
     rebalance_delay_ms: 100,
     max_bytes: 10_000,
     subscriber_retries: 1,
-    subscriber_retry_delay_ms: 5
+    subscriber_retry_delay_ms: 5,
+    sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
   ],
   producer: [
-    endpoints: [localhost: 9092],
+    endpoints: [kafka: 9092],
     topics: ["kaffe-test"],
     sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,9 +15,10 @@ config :kaffe,
     rebalance_delay_ms: 100,
     max_bytes: 10_000,
     subscriber_retries: 1,
-    subscriber_retry_delay_ms: 5,
+    subscriber_retry_delay_ms: 5
   ],
   producer: [
-    endpoints: [kafka: 9092],
-    topics: ["kaffe-test"]
+    endpoints: [localhost: 9092],
+    topics: ["kaffe-test"],
+    sasl: {:plain, "KAFFE_PRODUCER_USER", "KAFFE_PRODUCER_PASSWORD"}
   ]

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -18,8 +18,9 @@ defmodule Kaffe.Config do
     {ip |> String.to_atom(), port |> String.to_integer()}
   end
 
-  def sasl_config(%{mech: :plain, login: login, password: password}) when not is_nil(password) and not is_nil(login),
-    do: [sasl: {:plain, login, password}]
+  def sasl_config(%{mechanism: :plain, login: login, password: password})
+      when not is_nil(password) and not is_nil(login),
+      do: [sasl: {:plain, login, password}]
 
   def sasl_config(_), do: []
 

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -18,13 +18,10 @@ defmodule Kaffe.Config do
     {ip |> String.to_atom(), port |> String.to_integer()}
   end
 
-  def sasl_config({method, user_env, password_env}) do
-    case {method, System.get_env(user_env), System.get_env(password_env)} do
-      {:plain, nil, nil} -> []
-      {:plain, plain_auth_user, plain_auth_password} -> [sasl: {:plain, plain_auth_user, plain_auth_password}]
-      _ -> []
-    end
-  end
+  def sasl_config(%{mech: :plain, login: login, password: password}) when not is_nil(password) and not is_nil(login),
+    do: [sasl: {:plain, login, password}]
+
+  def sasl_config(_), do: []
 
   def ssl_config do
     ssl_config(client_cert(), client_cert_key())

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -18,6 +18,14 @@ defmodule Kaffe.Config do
     {ip |> String.to_atom(), port |> String.to_integer()}
   end
 
+  def sasl_config({method, user_env, password_env}) do
+    case {method, System.get_env(user_env), System.get_env(password_env)} do
+      {:plain, nil, nil} -> []
+      {:plain, plain_auth_user, plain_auth_password} -> [sasl: {:plain, plain_auth_user, plain_auth_password}]
+      _ -> []
+    end
+  end
+
   def ssl_config do
     ssl_config(client_cert(), client_cert_key())
   end

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -69,7 +69,14 @@ defmodule Kaffe.Config.Consumer do
   end
 
   def client_consumer_config do
-    default_client_consumer_config() ++ maybe_heroku_kafka_ssl()
+    default_client_consumer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+  end
+
+  def sasl_options do
+    case config_get(:sasl, nil) do
+      {:plain, user_env, password_env} -> Kaffe.Config.sasl_config({:plain, user_env, password_env})
+      _ -> []
+    end
   end
 
   def default_client_consumer_config do

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -73,10 +73,9 @@ defmodule Kaffe.Config.Consumer do
   end
 
   def sasl_options do
-    case config_get(:sasl, nil) do
-      {:plain, user_env, password_env} -> Kaffe.Config.sasl_config({:plain, user_env, password_env})
-      _ -> []
-    end
+    :sasl
+    |> config_get(%{})
+    |> Kaffe.Config.sasl_config()
   end
 
   def default_client_consumer_config do

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -19,7 +19,14 @@ defmodule Kaffe.Config.Producer do
   end
 
   def client_producer_config do
-    default_client_producer_config() ++ maybe_heroku_kafka_ssl()
+    default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+  end
+
+  def sasl_options do
+    case config_get(:sasl, nil) do
+      {:plain, user_env, password_env} -> Kaffe.Config.sasl_config({:plain, user_env, password_env})
+      _ -> []
+    end
   end
 
   def maybe_heroku_kafka_ssl do

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -23,10 +23,9 @@ defmodule Kaffe.Config.Producer do
   end
 
   def sasl_options do
-    case config_get(:sasl, nil) do
-      {:plain, user_env, password_env} -> Kaffe.Config.sasl_config({:plain, user_env, password_env})
-      _ -> []
-    end
+    :sasl
+    |> config_get(%{})
+    |> Kaffe.Config.sasl_config()
   end
 
   def maybe_heroku_kafka_ssl do

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -53,7 +53,7 @@ defmodule Kaffe.Config.ConsumerTest do
     sasl_config =
       :kaffe
       |> Application.get_env(:consumer)
-      |> Keyword.put(:sasl, %{mech: :plain, login: "Alice", password: "ecilA"})
+      |> Keyword.put(:sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
 
     Application.put_env(:kaffe, :consumer, sasl_config)
 

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -12,8 +12,12 @@ defmodule Kaffe.Config.ConsumerTest do
     end
 
     test "correct settings are extracted" do
-      System.delete_env("KAFFE_PRODUCER_USER")
-      System.delete_env("KAFFE_PRODUCER_PASSWORD")
+      no_sasl_config =
+        :kaffe
+        |> Application.get_env(:consumer)
+        |> Keyword.delete(:sasl)
+
+      Application.put_env(:kaffe, :consumer, no_sasl_config)
 
       expected = %{
         endpoints: [kafka: 9092],
@@ -46,8 +50,12 @@ defmodule Kaffe.Config.ConsumerTest do
   end
 
   test "correct settings with sasl plain are extracted" do
-    System.put_env("KAFFE_PRODUCER_USER", "Alice")
-    System.put_env("KAFFE_PRODUCER_PASSWORD", "ecilA")
+    sasl_config =
+      :kaffe
+      |> Application.get_env(:consumer)
+      |> Keyword.put(:sasl, %{mech: :plain, login: "Alice", password: "ecilA"})
+
+    Application.put_env(:kaffe, :consumer, sasl_config)
 
     expected = %{
       endpoints: [kafka: 9092],

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -12,6 +12,9 @@ defmodule Kaffe.Config.ConsumerTest do
     end
 
     test "correct settings are extracted" do
+      System.delete_env("KAFFE_PRODUCER_USER")
+      System.delete_env("KAFFE_PRODUCER_PASSWORD")
+
       expected = %{
         endpoints: [kafka: 9092],
         subscriber_name: :"kaffe-test-group",
@@ -40,6 +43,40 @@ defmodule Kaffe.Config.ConsumerTest do
 
       assert Kaffe.Config.Consumer.configuration() == expected
     end
+  end
+
+  test "correct settings with sasl plain are extracted" do
+    System.put_env("KAFFE_PRODUCER_USER", "Alice")
+    System.put_env("KAFFE_PRODUCER_PASSWORD", "ecilA")
+
+    expected = %{
+      endpoints: [kafka: 9092],
+      subscriber_name: :"kaffe-test-group",
+      consumer_group: "kaffe-test-group",
+      topics: ["kaffe-test"],
+      group_config: [
+        offset_commit_policy: :commit_to_kafka_v2,
+        offset_commit_interval_seconds: 10
+      ],
+      consumer_config: [
+        auto_start_producers: false,
+        allow_topic_auto_creation: false,
+        begin_offset: :earliest,
+        sasl: {:plain, "Alice", "ecilA"}
+      ],
+      message_handler: SilentMessage,
+      async_message_ack: false,
+      rebalance_delay_ms: 100,
+      max_bytes: 10_000,
+      min_bytes: 0,
+      max_wait_time: 10_000,
+      subscriber_retries: 1,
+      subscriber_retry_delay_ms: 5,
+      offset_reset_policy: :reset_by_subscriber,
+      worker_allocation_strategy: :worker_per_partition
+    }
+
+    assert Kaffe.Config.Consumer.configuration() == expected
   end
 
   describe "offset_reset_policy" do

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -39,7 +39,7 @@ defmodule Kaffe.Config.ProducerTest do
       sasl_config =
         :kaffe
         |> Application.get_env(:producer)
-        |> Keyword.put(:sasl, %{mech: :plain, login: "Alice", password: "ecilA"})
+        |> Keyword.put(:sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
 
       Application.put_env(:kaffe, :producer, sasl_config)
 

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -3,8 +3,12 @@ defmodule Kaffe.Config.ProducerTest do
 
   describe "configuration/0" do
     test "correct settings are extracted" do
-      System.delete_env("KAFFE_PRODUCER_USER")
-      System.delete_env("KAFFE_PRODUCER_PASSWORD")
+      no_sasl_config =
+        :kaffe
+        |> Application.get_env(:producer)
+        |> Keyword.delete(:sasl)
+
+      Application.put_env(:kaffe, :producer, no_sasl_config)
 
       expected = %{
         endpoints: [kafka: 9092],
@@ -32,8 +36,12 @@ defmodule Kaffe.Config.ProducerTest do
     end
 
     test "correct settings with sasl plain are extracted" do
-      System.put_env("KAFFE_PRODUCER_USER", "Alice")
-      System.put_env("KAFFE_PRODUCER_PASSWORD", "ecilA")
+      sasl_config =
+        :kaffe
+        |> Application.get_env(:producer)
+        |> Keyword.put(:sasl, %{mech: :plain, login: "Alice", password: "ecilA"})
+
+      Application.put_env(:kaffe, :producer, sasl_config)
 
       expected = %{
         endpoints: [kafka: 9092],

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -3,6 +3,9 @@ defmodule Kaffe.Config.ProducerTest do
 
   describe "configuration/0" do
     test "correct settings are extracted" do
+      System.delete_env("KAFFE_PRODUCER_USER")
+      System.delete_env("KAFFE_PRODUCER_PASSWORD")
+
       expected = %{
         endpoints: [kafka: 9092],
         producer_config: [
@@ -19,6 +22,36 @@ defmodule Kaffe.Config.ProducerTest do
             compression: :no_compression,
             min_compression_batch_size: 1024
           ]
+        ],
+        topics: ["kaffe-test"],
+        client_name: :kaffe_producer_client,
+        partition_strategy: :md5
+      }
+
+      assert Kaffe.Config.Producer.configuration() == expected
+    end
+
+    test "correct settings with sasl plain are extracted" do
+      System.put_env("KAFFE_PRODUCER_USER", "Alice")
+      System.put_env("KAFFE_PRODUCER_PASSWORD", "ecilA")
+
+      expected = %{
+        endpoints: [kafka: 9092],
+        producer_config: [
+          auto_start_producers: true,
+          allow_topic_auto_creation: false,
+          default_producer_config: [
+            required_acks: -1,
+            ack_timeout: 1000,
+            partition_buffer_limit: 512,
+            partition_onwire_limit: 1,
+            max_batch_size: 1_048_576,
+            max_retries: 3,
+            retry_backoff_ms: 500,
+            compression: :no_compression,
+            min_compression_batch_size: 1024
+          ],
+          sasl: {:plain, "Alice", "ecilA"}
         ],
         topics: ["kaffe-test"],
         client_name: :kaffe_producer_client,

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -87,6 +87,8 @@ defmodule Kaffe.ProducerTest do
     end
 
     test "md5" do
+      System.put_env("KAFFE_PRODUCER_USER", "Alice")
+      System.put_env("KAFFE_PRODUCER_PASSWORD", "ecilA")
       update_producer_config(:partition_strategy, :md5)
 
       :ok = Producer.produce_sync("topic2", "key1", "value")
@@ -97,8 +99,8 @@ defmodule Kaffe.ProducerTest do
 
       :ok = Producer.produce_sync("topic2", "key1", "value")
 
-      assert_receive [:produce_sync, "topic2", ^partition1, "key1", "value"],
-                     "Should receive the same partition for the same key"
+      assert_receive [:produce_sync, "topic2", ^partition1, "key1", "value"]
+      # "Should receive the same partition for the same key"
 
       :ok = Producer.produce_sync("topic2", "key2", "value")
       assert_receive [:produce_sync, "topic2", partition2, "key2", "value"]


### PR DESCRIPTION
Support SASL_PLAIN auth for kafka broker

related to [prev](https://github.com/spreedly/kaffe/pull/82) PR, without additional commits

Kafka broker can be configure like
`/usr/local/etc/kafka/server.properties`:

```
listeners=SASL_PLAINTEXT://localhost:9093
advertised.listeners=SASL_PLAINTEXT://localhost:9093
security.inter.broker.protocol=SASL_PLAINTEXT
sasl.mechanism.inter.broker.protocol=PLAIN
sasl.enabled.mechanisms=PLAIN
```
JAAS file `kafka_server_jaas.conf`:

```
KafkaServer {
org.apache.kafka.common.security.plain.PlainLoginModule required
username="admin"
password="admin-secret"
user_admin="admin-secret"
user_alice="alice-secret";
};
```
Export Kafka Options before start kafka broker:
`export KAFKA_OPTS="-Djava.security.auth.login.config=/Users/workspace/kafka/kafka_server_jaas.conf`
Start kafka broker:
`kafka-server-start /usr/local/etc/kafka/server.properties`