### PR TITLE
Runtime Consumer Config

### DIFF
--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -1,7 +1,11 @@
 defmodule Kaffe.Config.Consumer do
   import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
-  def configuration do
+  def configuration(overrides \\ %{}) do
+    Map.merge(base_config(), overrides)
+  end
+
+  def base_config() do
     %{
       endpoints: endpoints(),
       subscriber_name: subscriber_name(),

--- a/lib/kaffe/consumer.ex
+++ b/lib/kaffe/consumer.ex
@@ -61,8 +61,8 @@ defmodule Kaffe.Consumer do
   acknowledgement you will be able to process messages faster but will need to
   take on the burden of ensuring no messages are lost.
   """
-  def start_link do
-    config = Kaffe.Config.Consumer.configuration()
+  def start_link(opts \\ %{}) do
+    config = Kaffe.Config.Consumer.configuration(opts)
 
     @kafka.start_link_group_subscriber(
       config.subscriber_name,

--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -90,8 +90,9 @@ defmodule Kaffe.GroupManager do
   end
 
   @doc """
-  Subscribe to a new set of topics. The new list of subscribed topics will only include
-  the requested topics and none of the currently configured topics.
+  Subscribe to a new set of topics or list the currently subscribed topics. The
+  new list of subscribed topics will only include the requested topics and none
+  of the currently configured topics.
   """
   def handle_call({:subscribe_to_topics, requested_topics}, _from, %State{topics: topics} = state) do
     new_topics = requested_topics -- topics
@@ -100,9 +101,6 @@ defmodule Kaffe.GroupManager do
     {:reply, {:ok, new_topics}, %State{state | topics: state.topics ++ new_topics}}
   end
 
-  @doc """
-  List the currently subscribed topics
-  """
   def handle_call({:list_subscribed_topics}, _from, %State{topics: topics} = state) do
     {:reply, topics, state}
   end

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -48,9 +48,14 @@ defmodule Kaffe.Producer do
   end
 
   @doc """
-  Synchronously produce the `message_list` to `topic`
+  Synchronously produce the `message_list` to a `topic`.
 
-  `messages` must be a list of `{key, value}` tuples
+  The first argument must be the topic or the key.
+  `messages` may be a list of `{key, value}` tuples or simply a value
+
+  Not specifying the topic as the first argument is a simpler way to produce if
+  you've only given Producer a single topic for production and don't want to
+  specify the topic for each call.
 
   Returns:
 
@@ -61,17 +66,6 @@ defmodule Kaffe.Producer do
     produce_list(topic, message_list, global_partition_strategy())
   end
 
-  @doc """
-  Synchronously produce the given `key`/`value` to the first Kafka topic.
-
-  This is a simpler way to produce if you've only given Producer a single topic
-  for production and don't want to specify the topic for each call.
-
-  Returns:
-
-       * `:ok` on successfully producing the message
-       * `{:error, reason}` for any error
-  """
   def produce_sync(key, value) do
     topic = config().topics |> List.first()
     produce_value(topic, key, value)
@@ -91,11 +85,6 @@ defmodule Kaffe.Producer do
     produce_list(topic, message_list, fn _, _, _, _ -> partition end)
   end
 
-  @doc """
-  Synchronously produce the `key`/`value` to `topic`
-
-  See `produce_sync/2` for returns.
-  """
   def produce_sync(topic, key, value) do
     produce_value(topic, key, value)
   end

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -1,7 +1,15 @@
 defmodule Kaffe.Config.ConsumerTest do
   use ExUnit.Case
 
-  describe "configuration/0" do
+  describe "configuration/1" do
+    test "custom options override values returned from base config" do
+      expected_endpoints = [overridden: :endpoints]
+      %{endpoints: endpoints} = Kaffe.Config.Consumer.configuration(%{endpoints: expected_endpoints})
+      assert endpoints == expected_endpoints
+    end
+  end
+
+  describe "base_config/0" do
     setup do
       consumer_config =
         Application.get_env(:kaffe, :consumer)
@@ -45,7 +53,7 @@ defmodule Kaffe.Config.ConsumerTest do
         worker_allocation_strategy: :worker_per_partition
       }
 
-      assert Kaffe.Config.Consumer.configuration() == expected
+      assert Kaffe.Config.Consumer.base_config() == expected
     end
 
     test "string endpoints parsed correctly" do
@@ -83,7 +91,7 @@ defmodule Kaffe.Config.ConsumerTest do
         Application.put_env(:kaffe, :consumer, Keyword.put(config, :endpoints, endpoints))
       end)
 
-      assert Kaffe.Config.Consumer.configuration() == expected
+      assert Kaffe.Config.Consumer.base_config() == expected
     end
   end
 
@@ -125,7 +133,7 @@ defmodule Kaffe.Config.ConsumerTest do
       Application.put_env(:kaffe, :consumer, Keyword.put(config, :sasl, sasl))
     end)
 
-    assert Kaffe.Config.Consumer.configuration() == expected
+    assert Kaffe.Config.Consumer.base_config() == expected
   end
 
   describe "offset_reset_policy" do
@@ -136,7 +144,7 @@ defmodule Kaffe.Config.ConsumerTest do
 
       Application.put_env(:kaffe, :consumer, consumer_config)
 
-      assert Kaffe.Config.Consumer.configuration().offset_reset_policy == :reset_by_subscriber
+      assert Kaffe.Config.Consumer.base_config().offset_reset_policy == :reset_by_subscriber
     end
   end
 end

--- a/test/kaffe/consumer_test.exs
+++ b/test/kaffe/consumer_test.exs
@@ -32,4 +32,14 @@ defmodule Kaffe.ConsumerTest do
     Consumer.handle_message(c.topic, c.partition, c.message, state)
     assert_receive %{topic: ^topic, partition: ^partition, value: ^value}
   end
+
+  describe "start_link" do
+    test "can be started without any options" do
+      {:ok, _pid} = Consumer.start_link()
+    end
+
+    test "can be started with custom options" do
+      {:ok, _pid} = Consumer.start_link(%{topics: ["one-topic", "another-topic"]})
+    end
+  end
 end


### PR DESCRIPTION
* Add optional argument to `Kaffe.Consumer.start_link` so the configuration generated by Kaffe can be overridden at the time the `kaffe.Consumer` process is started.
* Remove duplicate `@doc` tags different clauses of the same function. These were generating warnings during compilation.

Fixes part of https://github.com/spreedly/kaffe/issues/74 https://github.com/spreedly/kaffe/issues/73