### PR TITLE
Runtime Producer Config

### DIFF
--- a/lib/kaffe.ex
+++ b/lib/kaffe.ex
@@ -14,13 +14,7 @@ defmodule Kaffe do
 
     Logger.debug("event#start=#{__MODULE__}")
 
-    if Application.get_env(:kaffe, :producer) do
-      Logger.debug("event#start_producer_client=#{__MODULE__}")
-      Kaffe.Producer.start_producer_client()
-    end
-
     children = []
-
     opts = [strategy: :one_for_one, name: Kaffe.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -1,7 +1,11 @@
 defmodule Kaffe.Config.Consumer do
   import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
-  def configuration do
+  def configuration(overrides \\ %{}) do
+    Map.merge(base_config(), overrides)
+  end
+
+  def base_config() do
     %{
       endpoints: endpoints(),
       subscriber_name: subscriber_name(),

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -1,10 +1,10 @@
 defmodule Kaffe.Config.Producer do
   import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
-  def configuration do
+  def configuration(producer_overrides \\ %{}) do
     %{
       endpoints: endpoints(),
-      producer_config: client_producer_config(),
+      producer_config: client_producer_config(producer_overrides),
       client_name: config_get(:client_name, :kaffe_producer_client),
       topics: producer_topics(),
       partition_strategy: config_get(:partition_strategy, :md5)
@@ -21,8 +21,10 @@ defmodule Kaffe.Config.Producer do
     end
   end
 
-  def client_producer_config do
-    default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+  def client_producer_config(overrides) do
+    base_config = default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+    overrides_keyword_list = Enum.into(overrides, [])
+    Keyword.merge(base_config, overrides_keyword_list)
   end
 
   def sasl_options do

--- a/lib/kaffe/consumer.ex
+++ b/lib/kaffe/consumer.ex
@@ -61,8 +61,8 @@ defmodule Kaffe.Consumer do
   acknowledgement you will be able to process messages faster but will need to
   take on the burden of ensuring no messages are lost.
   """
-  def start_link do
-    config = Kaffe.Config.Consumer.configuration()
+  def start_link(opts \\ %{}) do
+    config = Kaffe.Config.Consumer.configuration(opts)
 
     @kafka.start_link_group_subscriber(
       config.subscriber_name,

--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -90,8 +90,9 @@ defmodule Kaffe.GroupManager do
   end
 
   @doc """
-  Subscribe to a new set of topics. The new list of subscribed topics will only include
-  the requested topics and none of the currently configured topics.
+  Subscribe to a new set of topics or list the currently subscribed topics. The
+  new list of subscribed topics will only include the requested topics and none
+  of the currently configured topics.
   """
   def handle_call({:subscribe_to_topics, requested_topics}, _from, %State{topics: topics} = state) do
     new_topics = requested_topics -- topics
@@ -100,9 +101,6 @@ defmodule Kaffe.GroupManager do
     {:reply, {:ok, new_topics}, %State{state | topics: state.topics ++ new_topics}}
   end
 
-  @doc """
-  List the currently subscribed topics
-  """
   def handle_call({:list_subscribed_topics}, _from, %State{topics: topics} = state) do
     {:reply, topics, state}
   end

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -48,9 +48,14 @@ defmodule Kaffe.Producer do
   end
 
   @doc """
-  Synchronously produce the `message_list` to `topic`
+  Synchronously produce the `message_list` to a `topic`.
 
-  `messages` must be a list of `{key, value}` tuples
+  The first argument must be the topic or the key.
+  `messages` may be a list of `{key, value}` tuples or simply a value
+
+  Not specifying the topic as the first argument is a simpler way to produce if
+  you've only given Producer a single topic for production and don't want to
+  specify the topic for each call.
 
   Returns:
 
@@ -61,17 +66,6 @@ defmodule Kaffe.Producer do
     produce_list(topic, message_list, global_partition_strategy())
   end
 
-  @doc """
-  Synchronously produce the given `key`/`value` to the first Kafka topic.
-
-  This is a simpler way to produce if you've only given Producer a single topic
-  for production and don't want to specify the topic for each call.
-
-  Returns:
-
-       * `:ok` on successfully producing the message
-       * `{:error, reason}` for any error
-  """
   def produce_sync(key, value) do
     topic = config().topics |> List.first()
     produce_value(topic, key, value)
@@ -91,11 +85,6 @@ defmodule Kaffe.Producer do
     produce_list(topic, message_list, fn _, _, _, _ -> partition end)
   end
 
-  @doc """
-  Synchronously produce the `key`/`value` to `topic`
-
-  See `produce_sync/2` for returns.
-  """
   def produce_sync(topic, key, value) do
     produce_value(topic, key, value)
   end

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -27,8 +27,9 @@ defmodule Kaffe.Producer do
   ## public api
   ## -------------------------------------------------------------------------
 
-  def start_producer_client do
-    @kafka.start_client(config().endpoints, client_name(), config().producer_config)
+  def start_producer_client(opts \\ %{}) do
+    conf = config(opts)
+    @kafka.start_client(conf.endpoints, client_name(), conf.producer_config)
   end
 
   @doc """
@@ -177,7 +178,7 @@ defmodule Kaffe.Producer do
     config().partition_strategy
   end
 
-  defp config do
-    Kaffe.Config.Producer.configuration()
+  defp config(opts \\ %{}) do
+    Kaffe.Config.Producer.configuration(opts)
   end
 end

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -1,7 +1,15 @@
 defmodule Kaffe.Config.ConsumerTest do
   use ExUnit.Case
 
-  describe "configuration/0" do
+  describe "configuration/1" do
+    test "custom options override values returned from base config" do
+      expected_endpoints = [overridden: :endpoints]
+      %{endpoints: endpoints} = Kaffe.Config.Consumer.configuration(%{endpoints: expected_endpoints})
+      assert endpoints == expected_endpoints
+    end
+  end
+
+  describe "base_config/0" do
     setup do
       consumer_config =
         Application.get_env(:kaffe, :consumer)
@@ -45,7 +53,7 @@ defmodule Kaffe.Config.ConsumerTest do
         worker_allocation_strategy: :worker_per_partition
       }
 
-      assert Kaffe.Config.Consumer.configuration() == expected
+      assert Kaffe.Config.Consumer.base_config() == expected
     end
 
     test "string endpoints parsed correctly" do
@@ -83,7 +91,7 @@ defmodule Kaffe.Config.ConsumerTest do
         Application.put_env(:kaffe, :consumer, Keyword.put(config, :endpoints, endpoints))
       end)
 
-      assert Kaffe.Config.Consumer.configuration() == expected
+      assert Kaffe.Config.Consumer.base_config() == expected
     end
   end
 
@@ -125,7 +133,7 @@ defmodule Kaffe.Config.ConsumerTest do
       Application.put_env(:kaffe, :consumer, Keyword.put(config, :sasl, sasl))
     end)
 
-    assert Kaffe.Config.Consumer.configuration() == expected
+    assert Kaffe.Config.Consumer.base_config() == expected
   end
 
   describe "offset_reset_policy" do
@@ -136,7 +144,7 @@ defmodule Kaffe.Config.ConsumerTest do
 
       Application.put_env(:kaffe, :consumer, consumer_config)
 
-      assert Kaffe.Config.Consumer.configuration().offset_reset_policy == :reset_by_subscriber
+      assert Kaffe.Config.Consumer.base_config().offset_reset_policy == :reset_by_subscriber
     end
   end
 end

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -1,6 +1,13 @@
 defmodule Kaffe.Config.ProducerTest do
   use ExUnit.Case, async: true
 
+  describe "configuration/1" do
+    test "custom options override values returned from base config" do
+      %{producer_config: producer_config} = Kaffe.Config.Producer.configuration(%{allow_topic_auto_creation: false})
+      assert Keyword.get(producer_config, :allow_topic_auto_creation) == false
+    end
+  end
+
   describe "configuration/0" do
     test "correct settings are extracted" do
       no_sasl_config =

--- a/test/kaffe/consumer_test.exs
+++ b/test/kaffe/consumer_test.exs
@@ -32,4 +32,14 @@ defmodule Kaffe.ConsumerTest do
     Consumer.handle_message(c.topic, c.partition, c.message, state)
     assert_receive %{topic: ^topic, partition: ^partition, value: ^value}
   end
+
+  describe "start_link" do
+    test "can be started without any options" do
+      {:ok, _pid} = Consumer.start_link()
+    end
+
+    test "can be started with custom options" do
+      {:ok, _pid} = Consumer.start_link(%{topics: ["one-topic", "another-topic"]})
+    end
+  end
 end

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -7,6 +7,7 @@ defmodule Kaffe.ProducerTest do
     Process.register(self(), :test_case)
     update_producer_config(:topics, ["topic", "topic2"])
     update_producer_config(:partition_strategy, :md5)
+    :ok = Kaffe.Producer.start_producer_client()
     TestBrod.set_produce_response(:ok)
     :ok
   end

--- a/test/kaffe/producer_test.exs
+++ b/test/kaffe/producer_test.exs
@@ -137,6 +137,16 @@ defmodule Kaffe.ProducerTest do
     end
   end
 
+  describe "start_link" do
+    test "can be started without any options" do
+      assert :ok == Producer.start_producer_client()
+    end
+
+    test "can be started with custom options" do
+      assert :ok == Producer.start_producer_client(%{allow_topic_auto_creation: false})
+    end
+  end
+
   defp update_producer_config(key, value) do
     producer_config = Application.get_env(:kaffe, :producer)
     Application.put_env(:kaffe, :producer, put_in(producer_config, [key], value))


### PR DESCRIPTION
* Don't automatically start producer
* Add optional argument to `Kaffe.Producer.start_producer_client` so the configuration generated by Kaffe can be overridden at the time the `kaffe.Producer` process is started.