### PR TITLE
Fixes https://github.com/spreedly/kaffe/issues/84

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Batch message consumers receive a list of messages and work as part of the `:bro
     ```elixir
     config :kaffe,
       consumer: [
-        endpoints: [{"kafka", 9092}], # that's [{"hostname", kafka_port}]
+        endpoints: [kafka: 9092], # that's [hostname: kafka_port]
         topics: ["interesting-topic"], # the topic(s) that will be consumed
         consumer_group: "your-app-consumer-group", # the consumer group for tracking offsets in Kafka
         message_handler: MessageProcessor, # the module from Step 1 that will process messages
@@ -284,7 +284,7 @@ Configure your Kaffe Producer in your mix config
 ```elixir
 config :kaffe,
   producer: [
-    endpoints: [{"kafka", 9092}], # [{"hostname", port}]
+    endpoints: [kafka: 9092], # [hostname: port]
     topics: ["kafka-topic"],
 
     # optional

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Batch message consumers receive a list of messages and work as part of the `:bro
     ```elixir
     config :kaffe,
       consumer: [
-        endpoints: [kafka: 9092], # that's [hostname: kafka_port]
+        endpoints: [{"kafka", 9092}], # that's [{"hostname", kafka_port}]
         topics: ["interesting-topic"], # the topic(s) that will be consumed
         consumer_group: "your-app-consumer-group", # the consumer group for tracking offsets in Kafka
         message_handler: MessageProcessor, # the module from Step 1 that will process messages
@@ -284,11 +284,12 @@ Configure your Kaffe Producer in your mix config
 ```elixir
 config :kaffe,
   producer: [
-    endpoints: [kafka: 9092], # [hostname: port]
+    endpoints: [{"kafka", 9092}], # [{"hostname", port}]
     topics: ["kafka-topic"],
 
     # optional
     partition_strategy: :md5,
+    ssl: true
     sasl: %{
       mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),
@@ -305,7 +306,9 @@ The `partition_strategy` setting can be one of:
 
 You can also set any of the Brod producer configuration options in the `producer` section - see [the Brod sources](https://github.com/klarna/brod/blob/master/src/brod_producer.erl#L90) for a list of keys and their meaning.
 
-If kafka broker configured with `SASL_PLAINTEXT` auth, `sasl` option can be added
+If kafka broker configured with `SASL_PLAINTEXT` auth, `sasl` option can be added.
+
+If using Confluent Hosted Kafka, make sure `ssl` is `true`.
 
 ### Heroku Configuration
 

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -30,8 +30,12 @@ defmodule Kaffe.Config do
     ssl_config(client_cert(), client_cert_key())
   end
 
-  def ssl_config(bool) when is_boolean(bool) do
-    [ssl: bool]
+  def ssl_config(true) do
+    [ssl: true]
+  end
+
+  def ssl_config(_) do
+    []
   end
 
   def ssl_config(_client_cert = nil, _client_cert_key = nil) do

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -30,6 +30,10 @@ defmodule Kaffe.Config do
     ssl_config(client_cert(), client_cert_key())
   end
 
+  def ssl_config(bool) when is_boolean(bool) do
+    [ssl: bool]
+  end
+
   def ssl_config(_client_cert = nil, _client_cert_key = nil) do
     []
   end

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -72,13 +72,19 @@ defmodule Kaffe.Config.Consumer do
   end
 
   def client_consumer_config do
-    default_client_consumer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+    default_client_consumer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options() ++ ssl_options()
   end
 
   def sasl_options do
     :sasl
     |> config_get(%{})
     |> Kaffe.Config.sasl_config()
+  end
+
+  def ssl_options do
+    :ssl
+    |> config_get(false)
+    |> Kaffe.Config.ssl_config()
   end
 
   def default_client_consumer_config do

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -22,7 +22,7 @@ defmodule Kaffe.Config.Producer do
   end
 
   def client_producer_config do
-    default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options()
+    default_client_producer_config() ++ maybe_heroku_kafka_ssl() ++ sasl_options() ++ ssl_options()
   end
 
   def sasl_options do
@@ -36,6 +36,12 @@ defmodule Kaffe.Config.Producer do
       true -> Kaffe.Config.ssl_config()
       false -> []
     end
+  end
+
+  def ssl_options do
+    :ssl
+    |> config_get(false)
+    |> Kaffe.Config.ssl_config()
   end
 
   def default_client_producer_config do

--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -79,7 +79,9 @@ defmodule Kaffe.GroupManager do
   def handle_cast({:start_group_members}, state) do
     Logger.debug("Starting worker supervisors for group manager: #{inspect(self())}")
 
-    {:ok, worker_supervisor_pid} = group_member_supervisor().start_worker_supervisor(state.supervisor_pid, state.subscriber_name)
+    {:ok, worker_supervisor_pid} =
+      group_member_supervisor().start_worker_supervisor(state.supervisor_pid, state.subscriber_name)
+
     {:ok, worker_manager_pid} = worker_supervisor().start_worker_manager(worker_supervisor_pid, state.subscriber_name)
 
     state = %State{state | worker_manager_pid: worker_manager_pid}

--- a/lib/kaffe/consumer_group/subscriber/group_member.ex
+++ b/lib/kaffe/consumer_group/subscriber/group_member.ex
@@ -89,12 +89,10 @@ defmodule Kaffe.GroupMember do
         self()
       )
 
-    Logger.info(
-      "event#init=#{__MODULE__}
+    Logger.info("event#init=#{__MODULE__}
        group_coordinator=#{inspect(pid)}
        subscriber_name=#{subscriber_name}
-       consumer_group=#{consumer_group}"
-    )
+       consumer_group=#{consumer_group}")
 
     {:ok,
      %State{
@@ -124,7 +122,8 @@ defmodule Kaffe.GroupMember do
   end
 
   # If we're not at the latest generation, discard the assignment for whatever is next.
-  def handle_info({:allocate_subscribers, gen_id, _assignments}, %{current_gen_id: current_gen_id} = state) when gen_id < current_gen_id do
+  def handle_info({:allocate_subscribers, gen_id, _assignments}, %{current_gen_id: current_gen_id} = state)
+      when gen_id < current_gen_id do
     Logger.debug("Discarding old generation #{gen_id} for current generation: #{current_gen_id}")
     {:noreply, state}
   end
@@ -175,6 +174,7 @@ defmodule Kaffe.GroupMember do
   defp compute_offset(:undefined, configured_offset) do
     [begin_offset: configured_offset]
   end
+
   defp compute_offset(offset, _configured_offset) do
     [begin_offset: offset]
   end

--- a/lib/kaffe/consumer_group/subscriber/subscriber.ex
+++ b/lib/kaffe/consumer_group/subscriber/subscriber.ex
@@ -154,7 +154,11 @@ defmodule Kaffe.Subscriber do
   end
 
   def handle_cast({:commit_offsets, topic, partition, generation_id, offset}, state) do
-    Logger.debug("event#commit_offsets topic=#{state.topic} partition=#{state.partition} offset=#{offset} generation=#{generation_id}")
+    Logger.debug(
+      "event#commit_offsets topic=#{state.topic} partition=#{state.partition} offset=#{offset} generation=#{
+        generation_id
+      }"
+    )
 
     # Is this the ack we're looking for?
     ^topic = state.topic

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -132,10 +132,9 @@ defmodule Kaffe.Producer do
         )
 
         @kafka.produce_sync(client_name(), topic, partition, key, value)
+
       error ->
-        Logger.warn(
-          "event#produce topic=#{topic} key=#{key} error=#{inspect(error)}"
-        )
+        Logger.warn("event#produce topic=#{topic} key=#{key} error=#{inspect(error)}")
 
         error
     end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Kaffe.Mixfile do
 
   defp deps do
     [
-      {:brod, ">= 3.0.0 and < 3.5.0"},
+      {:brod, "~> 3.7"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Kaffe.Mixfile do
 
   defp deps do
     [
-      {:brod, "~> 3.7"},
+      {:brod, ">= 3.0.0 and < 3.5.0"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,11 @@
-%{"brod": {:hex, :brod, "3.2.0", "64f0778a7a32ec0a39cec9a564f4686bdfe72b147b48076e114a156fd0a30222", [:make, :rebar, :rebar3], [{:kafka_protocol, "1.1.0", [repo: "hexpm", hex: :kafka_protocol, optional: false]}, {:supervisor3, "1.1.5", [repo: "hexpm", hex: :supervisor3, optional: false]}], "hexpm"},
+%{
+  "brod": {:hex, :brod, "3.7.8", "ad4c26492e1d75d3382194dd841e68a716bb7f4bdf3c0aee35cd203e4512f3a3", [:make, :rebar, :rebar3], [{:kafka_protocol, "2.2.7", [hex: :kafka_protocol, repo: "hexpm", optional: false]}, {:supervisor3, "1.1.8", [hex: :supervisor3, repo: "hexpm", optional: false]}], "hexpm"},
+  "crc32cer": {:hex, :crc32cer, "0.1.3", "8984906c4b4fae6aa292c48f286a1c83b19ad44bd102287acb94d696015967ce", [:make, :rebar, :rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "kafka_protocol": {:hex, :kafka_protocol, "1.1.0", "817c07a6339cbfb32d1f20a588353bf8d9a8944df296eb2e930360b83760c171", [:rebar, :rebar3], [{:snappyer, "1.2.1", [repo: "hexpm", hex: :snappyer, optional: false]}], "hexpm"},
+  "kafka_protocol": {:hex, :kafka_protocol, "2.2.7", "a737a5714874ebd4a82f198f79cb438cda5d1054291b0b1c8f241448c332734d", [:rebar, :rebar3], [{:crc32cer, "0.1.3", [hex: :crc32cer, repo: "hexpm", optional: false]}, {:snappyer, "1.2.4", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
   "logfmt": {:hex, :logfmt, "3.2.0", "887a091adad28acc6e4d8b3d3bce177b934e7c61e7655c86946410f44aca6d84", [:mix], []},
   "metrix": {:git, "https://github.com/rwdaigle/metrix.git", "a6738df9346da0412ca68f82a24a67d2a32b066e", [branch: "master"]},
-  "snappyer": {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556", [:make, :rebar, :rebar3], [], "hexpm"},
-  "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], []}}
+  "snappyer": {:hex, :snappyer, "1.2.4", "6d739c534cd2339633127a2b40279be71f149e5842c5363a4d88e66efb7c1fec", [:make, :rebar, :rebar3], [], "hexpm"},
+  "supervisor3": {:hex, :supervisor3, "1.1.8", "5cf95c95342b589ec8d74689eea0646c0a3eb92820241e0c2d0ca4c104df92bc", [:make, :rebar, :rebar3], [], "hexpm"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,11 @@
 %{
-  "brod": {:hex, :brod, "3.7.8", "ad4c26492e1d75d3382194dd841e68a716bb7f4bdf3c0aee35cd203e4512f3a3", [:make, :rebar, :rebar3], [{:kafka_protocol, "2.2.7", [hex: :kafka_protocol, repo: "hexpm", optional: false]}, {:supervisor3, "1.1.8", [hex: :supervisor3, repo: "hexpm", optional: false]}], "hexpm"},
+  "brod": {:hex, :brod, "3.4.0", "34664713baaa60aed3b560c6a679cf90ace8dde8672732e730218db57440e37a", [:make, :rebar, :rebar3], [{:kafka_protocol, "1.1.2", [hex: :kafka_protocol, repo: "hexpm", optional: false]}, {:supervisor3, "1.1.5", [hex: :supervisor3, repo: "hexpm", optional: false]}], "hexpm"},
   "crc32cer": {:hex, :crc32cer, "0.1.3", "8984906c4b4fae6aa292c48f286a1c83b19ad44bd102287acb94d696015967ce", [:make, :rebar, :rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "kafka_protocol": {:hex, :kafka_protocol, "2.2.7", "a737a5714874ebd4a82f198f79cb438cda5d1054291b0b1c8f241448c332734d", [:rebar, :rebar3], [{:crc32cer, "0.1.3", [hex: :crc32cer, repo: "hexpm", optional: false]}, {:snappyer, "1.2.4", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
+  "kafka_protocol": {:hex, :kafka_protocol, "1.1.2", "96d09c4287377795ae2c488aceae2dc6872b94edba8309a27ace933d9ae32333", [:rebar, :rebar3], [{:snappyer, "1.2.1", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
   "logfmt": {:hex, :logfmt, "3.2.0", "887a091adad28acc6e4d8b3d3bce177b934e7c61e7655c86946410f44aca6d84", [:mix], []},
   "metrix": {:git, "https://github.com/rwdaigle/metrix.git", "a6738df9346da0412ca68f82a24a67d2a32b066e", [branch: "master"]},
-  "snappyer": {:hex, :snappyer, "1.2.4", "6d739c534cd2339633127a2b40279be71f149e5842c5363a4d88e66efb7c1fec", [:make, :rebar, :rebar3], [], "hexpm"},
-  "supervisor3": {:hex, :supervisor3, "1.1.8", "5cf95c95342b589ec8d74689eea0646c0a3eb92820241e0c2d0ca4c104df92bc", [:make, :rebar, :rebar3], [], "hexpm"},
+  "snappyer": {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556", [:make, :rebar, :rebar3], [], "hexpm"},
+  "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], [], "hexpm"},
 }

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -6,6 +6,7 @@ defmodule Kaffe.Config.ConsumerTest do
       consumer_config =
         Application.get_env(:kaffe, :consumer)
         |> Keyword.delete(:offset_reset_policy)
+        |> Keyword.delete(:ssl)
         |> Keyword.put(:start_with_earliest_message, true)
 
       Application.put_env(:kaffe, :consumer, consumer_config)
@@ -31,7 +32,7 @@ defmodule Kaffe.Config.ConsumerTest do
         consumer_config: [
           auto_start_producers: false,
           allow_topic_auto_creation: false,
-          begin_offset: :earliest
+          begin_offset: :earliest,
         ],
         message_handler: SilentMessage,
         async_message_ack: false,
@@ -123,6 +124,47 @@ defmodule Kaffe.Config.ConsumerTest do
 
     on_exit(fn ->
       Application.put_env(:kaffe, :consumer, Keyword.put(config, :sasl, sasl))
+    end)
+
+    assert Kaffe.Config.Consumer.configuration() == expected
+  end
+
+  test "correct settings with ssl are extracted" do
+    config = Application.get_env(:kaffe, :consumer)
+    ssl = Keyword.get(config, :ssl)
+    ssl_config = Keyword.put(config, :ssl, true)
+
+    Application.put_env(:kaffe, :consumer, ssl_config)
+
+    expected = %{
+      endpoints: [kafka: 9092],
+      subscriber_name: :"kaffe-test-group",
+      consumer_group: "kaffe-test-group",
+      topics: ["kaffe-test"],
+      group_config: [
+        offset_commit_policy: :commit_to_kafka_v2,
+        offset_commit_interval_seconds: 10
+      ],
+      consumer_config: [
+        auto_start_producers: false,
+        allow_topic_auto_creation: false,
+        begin_offset: :earliest,
+        ssl: true
+      ],
+      message_handler: SilentMessage,
+      async_message_ack: false,
+      rebalance_delay_ms: 100,
+      max_bytes: 10_000,
+      min_bytes: 0,
+      max_wait_time: 10_000,
+      subscriber_retries: 1,
+      subscriber_retry_delay_ms: 5,
+      offset_reset_policy: :reset_by_subscriber,
+      worker_allocation_strategy: :worker_per_partition
+    }
+
+    on_exit(fn ->
+      Application.put_env(:kaffe, :consumer, Keyword.put(config, :ssl, ssl))
     end)
 
     assert Kaffe.Config.Consumer.configuration() == expected

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -106,4 +106,39 @@ defmodule Kaffe.Config.ProducerTest do
 
     assert Kaffe.Config.Producer.configuration() == expected
   end
+
+  test "adds ssl when true" do
+    config = Application.get_env(:kaffe, :producer)
+    ssl = Keyword.get(config, :ssl)
+    Application.put_env(:kaffe, :producer, Keyword.put(config, :ssl, true))
+
+    expected = %{
+      endpoints: [kafka: 9092],
+      producer_config: [
+        auto_start_producers: true,
+        allow_topic_auto_creation: false,
+        default_producer_config: [
+          required_acks: -1,
+          ack_timeout: 1000,
+          partition_buffer_limit: 512,
+          partition_onwire_limit: 1,
+          max_batch_size: 1_048_576,
+          max_retries: 3,
+          retry_backoff_ms: 500,
+          compression: :no_compression,
+          min_compression_batch_size: 1024
+        ],
+        ssl: true
+      ],
+      topics: ["kaffe-test"],
+      client_name: :kaffe_producer_client,
+      partition_strategy: :md5
+    }
+
+    on_exit(fn ->
+      Application.put_env(:kaffe, :producer, Keyword.put(config, :ssl, ssl))
+    end)
+
+    assert Kaffe.Config.Producer.configuration() == expected
+  end
 end


### PR DESCRIPTION
Hi!

This PR does a few things:

First: ~bump the `brod` version~ *Edit:* turns out that wasn't needed!
Second: run `mix format`
Third: add support for `ssl: true` in producer/consumer configs

This will allow clients to connect to Confluent hosted Kafka!