### PR TITLE
Fix compatibilty with Brod versions > 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ There is also legacy support for single message consumers, which process one mes
             }
           ]
 
-          opts = [strategy: :one_for_one, name: Sample.Supervisor]
+          opts = [strategy: :one_for_one, name: MyApp.Application.Supervisor]
           Supervisor.start_link(children, opts)
         end
       end
@@ -148,7 +148,7 @@ In some cases you may not want to commit back the most recent offset after proce
 Example:
 
 ```elixir
-defmodule MessageProcessor
+defmodule MessageProcessor do
   def handle_messages(messages) do
     for %{key: key, value: value} = message <- messages do
       IO.inspect message

--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -5,8 +5,19 @@ defmodule Kaffe.Config do
     |> parse_endpoints()
   end
 
-  def parse_endpoints(endpoints) when is_list(endpoints), do: endpoints
+  @doc """
+  Transform the list of endpoints into a list of `{charlist, port}` tuples.
+  """
+  def parse_endpoints(endpoints) when is_list(endpoints) do
+    endpoints
+    |> Enum.map(fn {host, port} ->
+      {to_charlist(host), port}
+    end)
+  end
 
+  @doc """
+  Transform the encoded string into a list of `{charlist, port}` tuples.
+  """
   def parse_endpoints(url) when is_binary(url) do
     url
     |> String.replace("kafka+ssl://", "")
@@ -17,7 +28,7 @@ defmodule Kaffe.Config do
 
   def url_endpoint_to_tuple(endpoint) do
     [ip, port] = endpoint |> String.split(":")
-    {ip |> String.to_atom(), port |> String.to_integer()}
+    {ip |> String.to_charlist(), port |> String.to_integer()}
   end
 
   def sasl_config(%{mechanism: :plain, login: login, password: password})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Kaffe.Mixfile do
   def project do
     [
       app: :kaffe,
-      version: "1.13.0",
+      version: "1.14.0",
       description:
         "An opinionated Elixir wrapper around brod, the Erlang Kafka client, that supports encrypted connections to Heroku Kafka out of the box.",
       name: "Kaffe",
@@ -27,7 +27,7 @@ defmodule Kaffe.Mixfile do
 
   defp deps do
     [
-      {:brod, ">= 3.0.0 and < 3.5.0"},
+      {:brod, "~> 3.0"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
     ]
   end

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -21,7 +21,7 @@ defmodule Kaffe.Config.ConsumerTest do
       Application.put_env(:kaffe, :consumer, no_sasl_config)
 
       expected = %{
-        endpoints: [kafka: 9092],
+        endpoints: [{'kafka', 9092}],
         subscriber_name: :"kaffe-test-group",
         consumer_group: "kaffe-test-group",
         topics: ["kaffe-test"],
@@ -55,7 +55,7 @@ defmodule Kaffe.Config.ConsumerTest do
       Application.put_env(:kaffe, :consumer, Keyword.put(config, :endpoints, "kafka:9092,localhost:9092"))
 
       expected = %{
-        endpoints: [kafka: 9092, localhost: 9092],
+        endpoints: [{'kafka', 9092}, {'localhost', 9092}],
         subscriber_name: :"kaffe-test-group",
         consumer_group: "kaffe-test-group",
         topics: ["kaffe-test"],
@@ -96,7 +96,7 @@ defmodule Kaffe.Config.ConsumerTest do
     Application.put_env(:kaffe, :consumer, sasl_config)
 
     expected = %{
-      endpoints: [kafka: 9092],
+      endpoints: [{'kafka', 9092}],
       subscriber_name: :"kaffe-test-group",
       consumer_group: "kaffe-test-group",
       topics: ["kaffe-test"],
@@ -137,7 +137,7 @@ defmodule Kaffe.Config.ConsumerTest do
     Application.put_env(:kaffe, :consumer, ssl_config)
 
     expected = %{
-      endpoints: [kafka: 9092],
+      endpoints: [{'kafka', 9092}],
       subscriber_name: :"kaffe-test-group",
       consumer_group: "kaffe-test-group",
       topics: ["kaffe-test"],

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -11,7 +11,7 @@ defmodule Kaffe.Config.ProducerTest do
       Application.put_env(:kaffe, :producer, no_sasl_config)
 
       expected = %{
-        endpoints: [kafka: 9092],
+        endpoints: [{'kafka', 9092}],
         producer_config: [
           auto_start_producers: true,
           allow_topic_auto_creation: false,
@@ -43,7 +43,7 @@ defmodule Kaffe.Config.ProducerTest do
       Application.put_env(:kaffe, :producer, sasl_config)
 
       expected = %{
-        endpoints: [kafka: 9092],
+        endpoints: [{'kafka', 9092}],
         producer_config: [
           auto_start_producers: true,
           allow_topic_auto_creation: false,
@@ -79,7 +79,7 @@ defmodule Kaffe.Config.ProducerTest do
     Application.put_env(:kaffe, :producer, Keyword.put(config, :endpoints, "kafka:9092,localhost:9092"))
 
     expected = %{
-      endpoints: [kafka: 9092, localhost: 9092],
+      endpoints: [{'kafka', 9092}, {'localhost', 9092}],
       producer_config: [
         auto_start_producers: true,
         allow_topic_auto_creation: false,
@@ -113,7 +113,7 @@ defmodule Kaffe.Config.ProducerTest do
     Application.put_env(:kaffe, :producer, Keyword.put(config, :ssl, true))
 
     expected = %{
-      endpoints: [kafka: 9092],
+      endpoints: [{'kafka', 9092}],
       producer_config: [
         auto_start_producers: true,
         allow_topic_auto_creation: false,

--- a/test/kaffe/config_test.exs
+++ b/test/kaffe/config_test.exs
@@ -8,7 +8,7 @@ defmodule Kaffe.ConfigTest do
         "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
       )
 
-      expected = [{:"192.168.1.100", 9096}, {:"192.168.1.101", 9096}, {:"192.168.1.102", 9096}]
+      expected = [{'192.168.1.100', 9096}, {'192.168.1.101', 9096}, {'192.168.1.102', 9096}]
 
       on_exit(fn ->
         System.delete_env("KAFKA_URL")
@@ -19,7 +19,7 @@ defmodule Kaffe.ConfigTest do
 
     test "transforms endpoints into the correct format" do
       kafka_url = "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
-      expected = [{:"192.168.1.100", 9096}, {:"192.168.1.101", 9096}, {:"192.168.1.102", 9096}]
+      expected = [{'192.168.1.100', 9096}, {'192.168.1.101', 9096}, {'192.168.1.102', 9096}]
 
       assert Kaffe.Config.parse_endpoints(kafka_url) == expected
     end

--- a/test/kaffe/consumer_group/subscriber/group_member_startup_test.exs
+++ b/test/kaffe/consumer_group/subscriber/group_member_startup_test.exs
@@ -33,7 +33,7 @@ defmodule Kaffe.GroupMemberStartupTest do
     Application.put_env(:kaffe, :consumer, Keyword.put(consumer_config, :subscriber_name, "s2"))
     {:ok, _pid} = Kaffe.GroupMemberSupervisor.start_link()
 
-    :timer.sleep(Kaffe.Config.Consumer.configuration().rebalance_delay_ms + 100)
+    Process.sleep(Kaffe.Config.Consumer.configuration().rebalance_delay_ms + 100)
 
     assignments =
       Enum.reduce(0..31, %{}, fn _partition, map ->

--- a/test/kaffe/consumer_group/subscriber/subscriber_test.exs
+++ b/test/kaffe/consumer_group/subscriber/subscriber_test.exs
@@ -121,11 +121,8 @@ defmodule Kaffe.SubscriberTest do
     Enum.map(1..10, fn n ->
       Subscriber.kafka_message(
         offset: n,
-        magic_byte: 0,
-        attributes: 0,
         key: "key-#{n}",
-        value: "#{n}",
-        crc: -1
+        value: "#{n}"
       )
     end)
   end


### PR DESCRIPTION
A compatibility introduced to later versions of Brod prevented Kaffe
from working if endpoints were specified as atoms. After reporting the
issue to the Brod maintainers, they indicated that Brod wants charlists
(Erlang strings) for these values.

This commit converts binaries and atoms to charlists, so both should
work with older and newer versions of Brod.

Therefore, the Brod dependency is now specified as `~> 3.0`.

Fixes #75