### PR TITLE
Allow :already_present as a valid result from brod.create_client

### DIFF
--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -57,7 +57,13 @@ defmodule Kaffe.GroupManager do
     Logger.info("event#startup=#{__MODULE__} name=#{name()}")
 
     config = Kaffe.Config.Consumer.configuration()
-    :ok = kafka().start_client(config.endpoints, config.subscriber_name, config.consumer_config)
+    case kafka().start_client(config.endpoints, config.subscriber_name, config.consumer_config) do
+      :ok ->
+        :ok
+
+      {_, :already_present} ->
+        Logger.info("The brod client is already present, continuing.")
+    end
 
     GenServer.cast(self(), {:start_group_members})
 


### PR DESCRIPTION
Kaffe currently chokes if it's trying to create a `brod` client but gets a `{:error, :already_present}`. This might be the case when there are connection problems to Kafka or the `kaffe` consumer supervision tree is restarted (for whatever reason) and is, IMHO, not a failure case.

