### PR TITLE
Handle client down error

### DIFF
--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -119,7 +119,12 @@ defmodule Kaffe.Producer do
     message_list
     |> add_timestamp
     |> group_by_partition(topic, partition_strategy)
-    |> produce_list_to_topic(topic)
+    |> case do
+      messages = %{} -> produce_list_to_topic(messages, topic)
+      {:error, reason} ->
+        Logger.warn("Error while grouping by partition #{inspect(reason)}")
+        {:error, reason}
+    end
   end
 
   defp produce_value(topic, key, value) do
@@ -149,12 +154,12 @@ defmodule Kaffe.Producer do
   end
 
   defp group_by_partition(messages, topic, partition_strategy) do
-    {:ok, partitions_count} = @kafka.get_partitions_count(client_name(), topic)
-
-    messages
-    |> Enum.group_by(fn {_timestamp, key, message} ->
-      choose_partition(topic, partitions_count, key, message, partition_strategy)
-    end)
+    with {:ok, partitions_count} <- @kafka.get_partitions_count(client_name(), topic) do
+      messages
+      |> Enum.group_by(fn {_timestamp, key, message} ->
+        choose_partition(topic, partitions_count, key, message, partition_strategy)
+      end)
+    end
   end
 
   defp produce_list_to_topic(message_list, topic) do


### PR DESCRIPTION
Hi
Kaffe will crash in case Kafka is not reachable due to the following code:
`{:ok, partitions_count} = @kafka.get_partitions_count(client_name(), topic)`

For example:
> iex(node1@127.0.0.1)17> Kaffe.Producer.produce_sync("test", [{"key", "value"}])
> ** (MatchError) no match of right hand side value: {:error, :client_down}
>     (kaffe 1.15.0) lib/kaffe/producer.ex:152: Kaffe.Producer.group_by_partition/3
>     (kaffe 1.15.0) lib/kaffe/producer.ex:121: Kaffe.Producer.produce_list/3

But with my changes:
> iex(node1@127.0.0.1)18> Kaffe.Producer.produce_sync("test", [{"key", "value"}])
> {:error, :client_down}
