### PR TITLE
Allow Kaffe Group Manager to recover when Kafka is unreachable

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,6 +16,7 @@ config :kaffe,
     max_bytes: 10_000,
     subscriber_retries: 1,
     subscriber_retry_delay_ms: 5,
+    client_down_retry_expire: 15_000,
     sasl: %{
       mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -18,7 +18,10 @@ defmodule Kaffe.Config.Consumer do
       subscriber_retries: subscriber_retries(),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(),
       offset_reset_policy: offset_reset_policy(),
-      worker_allocation_strategy: worker_allocation_strategy()
+      worker_allocation_strategy: worker_allocation_strategy(),
+      client_down_retries: client_down_retries(),
+      client_down_retry_interval: client_down_retry_interval()
+
     }
   end
 
@@ -108,6 +111,14 @@ defmodule Kaffe.Config.Consumer do
 
   def worker_allocation_strategy do
     config_get(:worker_allocation_strategy, :worker_per_partition)
+  end
+
+  def client_down_retries do
+    config_get(:client_down_retries, 3)
+  end
+
+  def client_down_retry_interval do
+    config_get(:client_down_retry_interval, 10000)
   end
 
   def maybe_heroku_kafka_ssl do

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -19,9 +19,7 @@ defmodule Kaffe.Config.Consumer do
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(),
       offset_reset_policy: offset_reset_policy(),
       worker_allocation_strategy: worker_allocation_strategy(),
-      client_down_retries: client_down_retries(),
-      client_down_retry_interval: client_down_retry_interval()
-
+      client_down_retry_expire: client_down_retry_expire()
     }
   end
 
@@ -113,12 +111,8 @@ defmodule Kaffe.Config.Consumer do
     config_get(:worker_allocation_strategy, :worker_per_partition)
   end
 
-  def client_down_retries do
-    config_get(:client_down_retries, 3)
-  end
-
-  def client_down_retry_interval do
-    config_get(:client_down_retry_interval, 10000)
+  def client_down_retry_expire do
+    config_get(:client_down_retry_expire, 30_000)
   end
 
   def maybe_heroku_kafka_ssl do

--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -161,7 +161,7 @@ defmodule Kaffe.GroupManager do
     end
   end
 
-  defp do_a_retry?(true, error), do: raise(Kaffe.GroupManager.ClientDownException)
+  defp do_a_retry?(true, _error), do: raise(Kaffe.GroupManager.ClientDownException)
   defp do_a_retry?(false, error), do: raise(error)
 
   defp subscribe_to_topic(state, topic) do

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule Kaffe.Mixfile do
     [
       {:brod, "~> 3.0"},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
+      {:retry, "~> 0.14.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
   "metrix": {:git, "https://github.com/rwdaigle/metrix.git", "a6738df9346da0412ca68f82a24a67d2a32b066e", [branch: "master"]},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
+  "retry": {:hex, :retry, "0.14.1", "722d1b0cf87096b71213f5801d99fface7ca76adc83fc9dbf3e1daee952aef10", [:mix], [], "hexpm", "b3a609f286f6fe4f6b2c15f32cd4a8a60427d78d05d7b68c2dd9110981111ae0"},
   "snappyer": {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556", [:make, :rebar, :rebar3], [], "hexpm", "e09171f1c7106d4082db88a409d5648425b3699d55319c2cd09c4bb8cd1ba8a2"},
   "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], [], "hexpm", "e6f489d6b819df4d8f202eb00a77515a949bf87dae4d0a060f534722a63d8977"},
 }

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -43,7 +43,8 @@ defmodule Kaffe.Config.ConsumerTest do
         subscriber_retries: 1,
         subscriber_retry_delay_ms: 5,
         offset_reset_policy: :reset_by_subscriber,
-        worker_allocation_strategy: :worker_per_partition
+        worker_allocation_strategy: :worker_per_partition,
+        client_down_retry_expire: 15_000
       }
 
       assert Kaffe.Config.Consumer.configuration() == expected
@@ -77,7 +78,8 @@ defmodule Kaffe.Config.ConsumerTest do
         subscriber_retries: 1,
         subscriber_retry_delay_ms: 5,
         offset_reset_policy: :reset_by_subscriber,
-        worker_allocation_strategy: :worker_per_partition
+        worker_allocation_strategy: :worker_per_partition,
+        client_down_retry_expire: 15_000
       }
 
       on_exit(fn ->
@@ -119,7 +121,8 @@ defmodule Kaffe.Config.ConsumerTest do
       subscriber_retries: 1,
       subscriber_retry_delay_ms: 5,
       offset_reset_policy: :reset_by_subscriber,
-      worker_allocation_strategy: :worker_per_partition
+      worker_allocation_strategy: :worker_per_partition,
+      client_down_retry_expire: 15_000
     }
 
     on_exit(fn ->
@@ -160,7 +163,8 @@ defmodule Kaffe.Config.ConsumerTest do
       subscriber_retries: 1,
       subscriber_retry_delay_ms: 5,
       offset_reset_policy: :reset_by_subscriber,
-      worker_allocation_strategy: :worker_per_partition
+      worker_allocation_strategy: :worker_per_partition,
+      client_down_retry_expire: 15_000
     }
 
     on_exit(fn ->


### PR DESCRIPTION
**What is in this pull request**
This PR addresses issue #93 which allows the Group Manager to retry connecting group members to topics when Kafka is down. This works both in cases where Kafka is initially down when Group Manager is started, or when Group Manager and members are started successfully and Kafka becomes unreachable.

The retry is implemented with the `Retry` library, using exponential backoff. Connecting to topics will be retried for X amount of seconds, which is configurable with `Kaffe.Config.Consumer.configuration()`. The default is 30 seconds. This allows the Group Manager to recover within 30 seconds. Currently it simply doesn't recover at all.

When retry options are pruned completely, Group Manager will no longer be able to recover. This behavior is expected, because it is most likely that if re-connections are not possible in a set amount of time, intervention is required. Retrying indefinitely does not make sense in that case. 

This PR only includes Group Manager recovery. 

**Why this pull request**
We use Kaffe in production for both consuming Kafka and producing to Kafka. We noticed that in case of consuming from Kafka with a Group Manager the application basically dies when connection with Kafka is lost. The Group Manager isn't capable of recovering from this event by itself. Because we run most of our services in containers with Kubernetes, losing connections sometimes is part of the game. In these cases we like our services to be resilient by allowing them to recover themselves / reconnect with other services. Right now a container must be killed and restarted in order to regain connection with Kafka. 

The above problem is similar to the issue described in #93. I saw the proposed solution by involving another supervisor. I'm more in favor to address this in Kaffe if possible. I like to hear your thoughts on my proposed approach.