### PR TITLE
Fix undefined function exponential_backoff not found

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Kaffe.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :brod], mod: {Kaffe, []}]
+    [applications: [:logger, :brod, :retry], mod: {Kaffe, []}]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
This fixes issue #106. It's a relatively simple change. Also see the retry docs that mention this [here](https://github.com/safwank/ElixirRetry#installation)