### PR TITLE
Fix support for :worker_mod config in WorkerSupervisor

### DIFF
--- a/lib/kaffe/consumer_group/worker/worker_supervisor.ex
+++ b/lib/kaffe/consumer_group/worker/worker_supervisor.ex
@@ -19,7 +19,7 @@ defmodule Kaffe.WorkerSupervisor do
 
     Supervisor.start_child(
       pid,
-      worker(Kaffe.Worker, [message_handler, subscriber_name, worker_name],
+      worker(worker_mod(), [message_handler, subscriber_name, worker_name],
         id: :"worker_#{subscriber_name}_#{worker_name}"
       )
     )
@@ -38,5 +38,9 @@ defmodule Kaffe.WorkerSupervisor do
 
   defp name(subscriber_name) do
     :"#{__MODULE__}.#{subscriber_name}"
+  end
+
+  defp worker_mod do
+    Application.get_env(:kaffe, :worker_mod, Kaffe.Worker)
   end
 end


### PR DESCRIPTION
Hi,

There's `:worker_mod` app env that can be configured, currently used by the subscriber when calling `process_messages/5`.

The WorkerSupervisor starts `Kaffe.Worker` directly though, using the same setting, we can change consistently the worker implementation. I didn't identify other places that depend on the worker module.

Thanks!