### PR TITLE
Issue #22 Allow topic auto-creation as an option

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,6 +17,7 @@ config :kaffe,
     subscriber_retries: 1,
     subscriber_retry_delay_ms: 5,
     client_down_retry_expire: 15_000,
+    allow_topic_auto_creation: true,
     sasl: %{
       mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),
@@ -26,6 +27,7 @@ config :kaffe,
   producer: [
     endpoints: [kafka: 9092],
     topics: ["kaffe-test"],
+    allow_topic_auto_creation: true,
     sasl: %{
       mechanism: :plain,
       login: System.get_env("KAFFE_PRODUCER_USER"),

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -91,7 +91,7 @@ defmodule Kaffe.Config.Consumer do
   def default_client_consumer_config do
     [
       auto_start_producers: false,
-      allow_topic_auto_creation: true,
+      allow_topic_auto_creation: config_get(:allow_topic_auto_creation, false),
       begin_offset: begin_offset()
     ]
   end

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -91,7 +91,7 @@ defmodule Kaffe.Config.Consumer do
   def default_client_consumer_config do
     [
       auto_start_producers: false,
-      allow_topic_auto_creation: false,
+      allow_topic_auto_creation: true,
       begin_offset: begin_offset()
     ]
   end

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -47,7 +47,7 @@ defmodule Kaffe.Config.Producer do
   def default_client_producer_config do
     [
       auto_start_producers: true,
-      allow_topic_auto_creation: false,
+      allow_topic_auto_creation: config_get(:allow_topic_auto_creation, false),
       default_producer_config: [
         required_acks: config_get(:required_acks, -1),
         ack_timeout: config_get(:ack_timeout, 1000),

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -31,7 +31,7 @@ defmodule Kaffe.Config.ConsumerTest do
         ],
         consumer_config: [
           auto_start_producers: false,
-          allow_topic_auto_creation: false,
+          allow_topic_auto_creation: true,
           begin_offset: :earliest
         ],
         message_handler: SilentMessage,
@@ -66,7 +66,7 @@ defmodule Kaffe.Config.ConsumerTest do
         ],
         consumer_config: [
           auto_start_producers: false,
-          allow_topic_auto_creation: false,
+          allow_topic_auto_creation: true,
           begin_offset: :earliest
         ],
         message_handler: SilentMessage,
@@ -108,7 +108,7 @@ defmodule Kaffe.Config.ConsumerTest do
       ],
       consumer_config: [
         auto_start_producers: false,
-        allow_topic_auto_creation: false,
+        allow_topic_auto_creation: true,
         begin_offset: :earliest,
         sasl: {:plain, "Alice", "ecilA"}
       ],
@@ -150,7 +150,7 @@ defmodule Kaffe.Config.ConsumerTest do
       ],
       consumer_config: [
         auto_start_producers: false,
-        allow_topic_auto_creation: false,
+        allow_topic_auto_creation: true,
         begin_offset: :earliest,
         ssl: true
       ],

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -14,7 +14,7 @@ defmodule Kaffe.Config.ProducerTest do
         endpoints: [{'kafka', 9092}],
         producer_config: [
           auto_start_producers: true,
-          allow_topic_auto_creation: false,
+          allow_topic_auto_creation: true,
           default_producer_config: [
             required_acks: -1,
             ack_timeout: 1000,
@@ -46,7 +46,7 @@ defmodule Kaffe.Config.ProducerTest do
         endpoints: [{'kafka', 9092}],
         producer_config: [
           auto_start_producers: true,
-          allow_topic_auto_creation: false,
+          allow_topic_auto_creation: true,
           default_producer_config: [
             required_acks: -1,
             ack_timeout: 1000,
@@ -82,7 +82,7 @@ defmodule Kaffe.Config.ProducerTest do
       endpoints: [{'kafka', 9092}, {'localhost', 9092}],
       producer_config: [
         auto_start_producers: true,
-        allow_topic_auto_creation: false,
+        allow_topic_auto_creation: true,
         default_producer_config: [
           required_acks: -1,
           ack_timeout: 1000,
@@ -116,7 +116,7 @@ defmodule Kaffe.Config.ProducerTest do
       endpoints: [{'kafka', 9092}],
       producer_config: [
         auto_start_producers: true,
-        allow_topic_auto_creation: false,
+        allow_topic_auto_creation: true,
         default_producer_config: [
           required_acks: -1,
           ack_timeout: 1000,


### PR DESCRIPTION
Hello Folks, 

It would be really useful to allow topic-auto creation from both the publisher and consumer since sometimes it is a lot more complicated to do it from the Docker container.

Let me know if the code looks or if you want any changes.