### PR TITLE
Bugfix: Match on subscribe_to_topics success to avoid getting stuck

### DIFF
--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -102,7 +102,7 @@ defmodule Kaffe.GroupManager do
 
     state = %State{state | worker_manager_pid: worker_manager_pid}
 
-    subscribe_to_topics(state, state.topics)
+    :ok = subscribe_to_topics(state, state.topics)
 
     {:noreply, state}
   end
@@ -113,7 +113,7 @@ defmodule Kaffe.GroupManager do
   """
   def handle_call({:subscribe_to_topics, requested_topics}, _from, %State{topics: topics} = state) do
     new_topics = requested_topics -- topics
-    subscribe_to_topics(state, new_topics)
+    :ok = subscribe_to_topics(state, new_topics)
 
     {:reply, {:ok, new_topics}, %State{state | topics: state.topics ++ new_topics}}
   end


### PR DESCRIPTION
In case the kafka cluster is temporarily unavailable, when subscribe_to_topics retries are exhausted, it simply exits the function without crashing.

When kafka cluster is back, if that happened after `client_down_retry_expire`, it won't subscribe to topics, and the consumer gets stuck.

With this change, it will crash after retries are exhausted and topic subscription didn't complete successfully, restarting properly as expected.