### PR TITLE
Remove deprecated supervisor spec

### DIFF
--- a/lib/kaffe/consumer_group/group_member_supervisor.ex
+++ b/lib/kaffe/consumer_group/group_member_supervisor.ex
@@ -32,7 +32,14 @@ defmodule Kaffe.GroupMemberSupervisor do
   end
 
   def start_worker_supervisor(supervisor_pid, subscriber_name) do
-    Supervisor.start_child(supervisor_pid, supervisor(Kaffe.WorkerSupervisor, [subscriber_name]))
+    Supervisor.start_child(
+      supervisor_pid,
+      %{
+        id: :"Kaffe.WorkerSupervisor.#{subscriber_name}",
+        start: {Kaffe.WorkerSupervisor, :start_link, [subscriber_name]},
+        type: :supervisor
+      }
+    )
   end
 
   def start_group_member(
@@ -44,11 +51,14 @@ defmodule Kaffe.GroupMemberSupervisor do
       ) do
     Supervisor.start_child(
       supervisor_pid,
-      worker(
-        Kaffe.GroupMember,
-        [subscriber_name, consumer_group, worker_manager_pid, topic],
-        id: :"group_member_#{subscriber_name}_#{topic}"
-      )
+      %{
+        id: :"group_member_#{subscriber_name}_#{topic}",
+        start: {
+          Kaffe.GroupMember,
+          :start_link,
+          [subscriber_name, consumer_group, worker_manager_pid, topic]
+        }
+      }
     )
   end
 
@@ -56,11 +66,14 @@ defmodule Kaffe.GroupMemberSupervisor do
     Logger.info("event#starting=#{__MODULE__}")
 
     children = [
-      worker(Kaffe.GroupManager, [])
+      %{
+        id: Kaffe.GroupManager,
+        start: {Kaffe.GroupManager, :start_link, []}
+      }
     ]
 
     # If we get a failure, we need to reset so the states are all consistent.
-    supervise(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
+    Supervisor.init(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
   end
 
   defp name do

--- a/lib/kaffe/consumer_group/worker/worker_supervisor.ex
+++ b/lib/kaffe/consumer_group/worker/worker_supervisor.ex
@@ -11,7 +11,10 @@ defmodule Kaffe.WorkerSupervisor do
   end
 
   def start_worker_manager(pid, subscriber_name) do
-    Supervisor.start_child(pid, worker(Kaffe.WorkerManager, [subscriber_name]))
+    Supervisor.start_child(
+      pid,
+      {Kaffe.WorkerManager, subscriber_name}
+    )
   end
 
   def start_worker(pid, message_handler, subscriber_name, worker_name) do
@@ -19,9 +22,14 @@ defmodule Kaffe.WorkerSupervisor do
 
     Supervisor.start_child(
       pid,
-      worker(Kaffe.Worker, [message_handler, subscriber_name, worker_name],
-        id: :"worker_#{subscriber_name}_#{worker_name}"
-      )
+      %{
+        id: :"worker_#{subscriber_name}_#{worker_name}",
+        start: {
+          Kaffe.Worker,
+          :start_link,
+          [message_handler, subscriber_name, worker_name]
+        }
+      }
     )
   end
 
@@ -33,7 +41,7 @@ defmodule Kaffe.WorkerSupervisor do
     # If anything fails, the state is inconsistent with the state of
     # `Kaffe.Subscriber` and `Kaffe.GroupMember`. We need the failure
     # to cascade all the way up so that they are terminated.
-    supervise(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
+    Supervisor.init(children, strategy: :one_for_all, max_restarts: 0, max_seconds: 1)
   end
 
   defp name(subscriber_name) do


### PR DESCRIPTION
Remove the deprecations listed below.

Elixir `~> 1.7`, already specified in `mix.exs` as dependency, already includes the child specs: https://github.com/elixir-lang/elixir/commit/43f80d382b22f03fe021206b234abdabb91b49da

```
warning: Supervisor.Spec.supervise/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/group_member_supervisor.ex:63: Kaffe.GroupMemberSupervisor.init/1

warning: Supervisor.Spec.supervise/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/worker/worker_supervisor.ex:36: Kaffe.WorkerSupervisor.init/1

warning: Supervisor.Spec.supervisor/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/group_member_supervisor.ex:35: Kaffe.GroupMemberSupervisor.start_worker_supervisor/2

warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/worker/worker_supervisor.ex:14: Kaffe.WorkerSupervisor.start_worker_manager/2

warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/group_member_supervisor.ex:59: Kaffe.GroupMemberSupervisor.init/1

warning: Supervisor.Spec.worker/3 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/worker/worker_supervisor.ex:22: Kaffe.WorkerSupervisor.start_worker/4

warning: Supervisor.Spec.worker/3 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/kaffe/consumer_group/group_member_supervisor.ex:47: Kaffe.GroupMemberSupervisor.start_group_member/5
```

