### PR TITLE
Fix crypto:rand_uniform deprecation

### DIFF
--- a/lib/kaffe/partition_selector.ex
+++ b/lib/kaffe/partition_selector.ex
@@ -24,8 +24,8 @@ defmodule Kaffe.PartitionSelector do
     end
   end
 
-  def random(total) do
-    :crypto.rand_uniform(0, total)
+  def random(total) when total >= 1 do
+    :rand.uniform(total) - 1
   end
 
   def md5(key, total) do


### PR DESCRIPTION
```
warning: :crypto.rand_uniform/2 is deprecated. Use rand:uniform/1 instead
  lib/kaffe/partition_selector.ex:28: Kaffe.PartitionSelector.random/1
```

https://www.erlang.org/doc/man/crypto.html#rand_uniform-2

https://www.erlang.org/doc/man/rand.html#uniform-1