### PR TITLE
Bump kaffe version to 1.21

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Kaffe.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/spreedly/kaffe"
-  @version "1.20.0"
+  @version "1.21.0"
 
   def project do
     [
@@ -44,7 +44,7 @@ defmodule Kaffe.Mixfile do
         "An opinionated Elixir wrapper around brod, the Erlang Kafka client, " <>
           "that supports encrypted connections to Heroku Kafka out of the box.",
       licenses: ["MIT"],
-      maintainers: ["Kevin Lewis", "David Santoso", "Ryan Daigle", "Spreedly", "Joe Peck"],
+      maintainers: ["Kevin Lewis", "David Santoso", "Ryan Daigle", "Spreedly", "Joe Peck", "Brittany Hayes"],
       links: %{
         "GitHub" => @source_url
       }


### PR DESCRIPTION
mix test
4 doctests, 47 tests, 0 failures, 1 excluded

mix test --only e2e
4 doctests, 47 tests, 0 failures, 50 excluded