### PR TITLE
Bump kaffe version to 1.22

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Kaffe.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/spreedly/kaffe"
-  @version "1.21.0"
+  @version "1.22.0"
 
   def project do
     [


### PR DESCRIPTION
Includes updates from #124 

mix test
4 doctests, 47 tests, 0 failures, 1 excluded

mix test --only e2e
4 doctests, 47 tests, 0 failures, 50 excluded