### PR TITLE
Support custom client_name in all public functions

### DIFF
--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -50,6 +50,10 @@ defmodule Kaffe.Producer do
     @kafka.start_client(config().endpoints, client_name(), config().producer_config)
   end
 
+  def stop_producer_client(client_name \\ client_name()) do
+    @kafka.stop_client(client_name)
+  end
+
   @doc """
   Synchronously produce the `messages_list` to `topic`
 
@@ -139,7 +143,9 @@ defmodule Kaffe.Producer do
     |> add_timestamp
     |> group_by_partition(topic, partition_strategy)
     |> case do
-      messages = %{} -> produce_list_to_topic(messages, topic)
+      messages = %{} ->
+        produce_list_to_topic(messages, topic)
+
       {:error, reason} ->
         Logger.warn("Error while grouping by partition #{inspect(reason)}")
         {:error, reason}
@@ -156,10 +162,9 @@ defmodule Kaffe.Producer do
         )
 
         @kafka.produce_sync(client_name(), topic, partition, key, value)
+
       error ->
-        Logger.warn(
-          "event#produce topic=#{topic} key=#{key} error=#{inspect(error)}"
-        )
+        Logger.warn("event#produce topic=#{topic} key=#{key} error=#{inspect(error)}")
 
         error
     end


### PR DESCRIPTION
Hi,

I've implemented new public functions to accept the `client_name` as parameter and a new function to stop the client to a given `client_name`.

It's useful to switch the Kafka cluster in runtime. In order to do it I need to start a new client to the new endpoint, produce the events to the new client and then stop the old client.