### PR TITLE
Upgrades Elixir to a supported version and bumps Kaffe version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,14 @@ defmodule Kaffe.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/spreedly/kaffe"
-  @version "1.22.0"
+  @version "1.23.0"
 
   def project do
     [
       app: :kaffe,
       version: @version,
       name: "Kaffe",
-      elixir: "~> 1.7",
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -44,7 +44,7 @@ defmodule Kaffe.Mixfile do
         "An opinionated Elixir wrapper around brod, the Erlang Kafka client, " <>
           "that supports encrypted connections to Heroku Kafka out of the box.",
       licenses: ["MIT"],
-      maintainers: ["Kevin Lewis", "David Santoso", "Ryan Daigle", "Spreedly", "Joe Peck", "Brittany Hayes"],
+      maintainers: ["Kevin Lewis", "David Santoso", "Ryan Daigle", "Spreedly", "Joe Peck", "Brittany Hayes", "Anthony Walker"],
       links: %{
         "GitHub" => @source_url
       }


### PR DESCRIPTION
Upgrades the Elixir dependency to a supported version: 1.12

Successful tests:

```
mix test
4 doctests, 47 tests, 0 failures, 1 excluded
```

```
mix test --only e2e
4 doctests, 47 tests, 0 failures, 50 excluded
```