### PR TITLE
Apply mix format and fix some compilation warnings

### DIFF
--- a/lib/kaffe/config.ex
+++ b/lib/kaffe/config.ex
@@ -6,7 +6,7 @@ defmodule Kaffe.Config do
   end
 
   @doc """
-  Transform the list of endpoints into a list of `{charlist, port}` tuples.
+  Transform a list of endpoints or an encoded string into a list of `{charlist, port}` tuples.
   """
   def parse_endpoints(endpoints) when is_list(endpoints) do
     endpoints
@@ -15,9 +15,6 @@ defmodule Kaffe.Config do
     end)
   end
 
-  @doc """
-  Transform the encoded string into a list of `{charlist, port}` tuples.
-  """
   def parse_endpoints(url) when is_binary(url) do
     url
     |> String.replace("kafka+ssl://", "")
@@ -53,6 +50,7 @@ defmodule Kaffe.Config do
   def ssl_config(_), do: []
 
   def ssl_config(_client_cert = nil, _client_cert_key = nil), do: []
+
   def ssl_config(client_cert, client_cert_key) do
     [
       ssl: [

--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -41,6 +41,7 @@ defmodule Kaffe.GroupManager do
   ## ==========================================================================
   ## Public API
   ## ==========================================================================
+  @spec start_link(any()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link(config) do
     GenServer.start_link(__MODULE__, [self(), config], name: name(config))
   end
@@ -98,7 +99,8 @@ defmodule Kaffe.GroupManager do
     {:ok, worker_supervisor_pid} =
       group_member_supervisor().start_worker_supervisor(state.supervisor_pid, state.subscriber_name)
 
-    {:ok, worker_manager_pid} = worker_supervisor().start_worker_manager(worker_supervisor_pid, state.subscriber_name, state.config)
+    {:ok, worker_manager_pid} =
+      worker_supervisor().start_worker_manager(worker_supervisor_pid, state.subscriber_name, state.config)
 
     state = %State{state | worker_manager_pid: worker_manager_pid}
 
@@ -107,10 +109,8 @@ defmodule Kaffe.GroupManager do
     {:noreply, state}
   end
 
-  @doc """
-  Subscribe to a new set of topics. The new list of subscribed topics will only include
-  the requested topics and none of the currently configured topics.
-  """
+  # Subscribe to a new set of topics. The new list of subscribed topics will only include
+  # the requested topics and none of the currently configured topics.
   def handle_call({:subscribe_to_topics, requested_topics}, _from, %State{topics: topics} = state) do
     new_topics = requested_topics -- topics
     :ok = subscribe_to_topics(state, new_topics)
@@ -118,9 +118,7 @@ defmodule Kaffe.GroupManager do
     {:reply, {:ok, new_topics}, %State{state | topics: state.topics ++ new_topics}}
   end
 
-  @doc """
-  List the currently subscribed topics
-  """
+  # List the currently subscribed topics
   def handle_call({:list_subscribed_topics}, _from, %State{topics: topics} = state) do
     {:reply, topics, state}
   end

--- a/lib/kaffe/consumer_group/group_manager.ex
+++ b/lib/kaffe/consumer_group/group_manager.ex
@@ -41,7 +41,6 @@ defmodule Kaffe.GroupManager do
   ## ==========================================================================
   ## Public API
   ## ==========================================================================
-  @spec start_link(any()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link(config) do
     GenServer.start_link(__MODULE__, [self(), config], name: name(config))
   end

--- a/lib/kaffe/consumer_group/subscriber/group_member.ex
+++ b/lib/kaffe/consumer_group/subscriber/group_member.ex
@@ -91,12 +91,10 @@ defmodule Kaffe.GroupMember do
         self()
       )
 
-    Logger.info(
-      "event#init=#{__MODULE__}
+    Logger.info("event#init=#{__MODULE__}
        group_coordinator=#{inspect(pid)}
        subscriber_name=#{subscriber_name}
-       consumer_group=#{consumer_group}"
-    )
+       consumer_group=#{consumer_group}")
 
     {:ok,
      %State{
@@ -127,7 +125,8 @@ defmodule Kaffe.GroupMember do
   end
 
   # If we're not at the latest generation, discard the assignment for whatever is next.
-  def handle_info({:allocate_subscribers, gen_id, _assignments}, %{current_gen_id: current_gen_id} = state) when gen_id < current_gen_id do
+  def handle_info({:allocate_subscribers, gen_id, _assignments}, %{current_gen_id: current_gen_id} = state)
+      when gen_id < current_gen_id do
     Logger.debug("Discarding old generation #{gen_id} for current generation: #{current_gen_id}")
     {:noreply, state}
   end
@@ -179,6 +178,7 @@ defmodule Kaffe.GroupMember do
   defp compute_offset(:undefined, configured_offset) do
     [begin_offset: configured_offset]
   end
+
   defp compute_offset(offset, _configured_offset) do
     [begin_offset: offset]
   end

--- a/lib/kaffe/consumer_group/subscriber/subscriber.ex
+++ b/lib/kaffe/consumer_group/subscriber/subscriber.ex
@@ -137,9 +137,7 @@ defmodule Kaffe.Subscriber do
 
   def handle_info({_pid, {:kafka_fetch_error, topic, partition, code, reason} = error}, state) do
     Logger.info(
-      "event#kafka_fetch_error=#{inspect(self())} topic=#{topic} partition=#{partition} code=#{inspect(code)} reason=#{
-        inspect(reason)
-      }"
+      "event#kafka_fetch_error=#{inspect(self())} topic=#{topic} partition=#{partition} code=#{inspect(code)} reason=#{inspect(reason)}"
     )
 
     {:stop, {:shutdown, error}, state}
@@ -157,7 +155,9 @@ defmodule Kaffe.Subscriber do
   end
 
   def handle_cast({:commit_offsets, topic, partition, generation_id, offset}, state) do
-    Logger.debug("event#commit_offsets topic=#{state.topic} partition=#{state.partition} offset=#{offset} generation=#{generation_id}")
+    Logger.debug(
+      "event#commit_offsets topic=#{state.topic} partition=#{state.partition} offset=#{offset} generation=#{generation_id}"
+    )
 
     # Is this the ack we're looking for?
     ^topic = state.topic

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -139,7 +139,9 @@ defmodule Kaffe.Producer do
     |> add_timestamp
     |> group_by_partition(topic, partition_strategy)
     |> case do
-      messages = %{} -> produce_list_to_topic(messages, topic)
+      messages = %{} ->
+        produce_list_to_topic(messages, topic)
+
       {:error, reason} ->
         Logger.warning("Error while grouping by partition #{inspect(reason)}")
         {:error, reason}
@@ -156,10 +158,9 @@ defmodule Kaffe.Producer do
         )
 
         @kafka.produce_sync(client_name(), topic, partition, key, value)
+
       error ->
-        Logger.warning(
-          "event#produce topic=#{topic} key=#{key} error=#{inspect(error)}"
-        )
+        Logger.warning("event#produce topic=#{topic} key=#{key} error=#{inspect(error)}")
 
         error
     end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,15 @@ defmodule Kaffe.Mixfile do
         "An opinionated Elixir wrapper around brod, the Erlang Kafka client, " <>
           "that supports encrypted connections to Heroku Kafka out of the box.",
       licenses: ["MIT"],
-      maintainers: ["Kevin Lewis", "David Santoso", "Ryan Daigle", "Spreedly", "Joe Peck", "Brittany Hayes", "Anthony Walker"],
+      maintainers: [
+        "Kevin Lewis",
+        "David Santoso",
+        "Ryan Daigle",
+        "Spreedly",
+        "Joe Peck",
+        "Brittany Hayes",
+        "Anthony Walker"
+      ],
       links: %{
         "GitHub" => @source_url
       }

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -9,7 +9,7 @@ defmodule Kaffe.Config.ConsumerTest do
 
   describe "configuration/1" do
     setup do
-      change_config("subscriber_name", fn(config) ->
+      change_config("subscriber_name", fn config ->
         config
         |> Keyword.delete(:offset_reset_policy)
         |> Keyword.delete(:ssl)
@@ -19,12 +19,13 @@ defmodule Kaffe.Config.ConsumerTest do
 
     test "correct settings are extracted" do
       sasl = Kaffe.Config.Consumer.config_get!("subscriber_name", :sasl)
-      change_config("subscriber_name", fn(config) ->
+
+      change_config("subscriber_name", fn config ->
         config |> Keyword.delete(:sasl)
       end)
 
       expected = %{
-        endpoints: [{'kafka', 9092}],
+        endpoints: [{~c"kafka", 9092}],
         subscriber_name: :subscriber_name,
         consumer_group: "kaffe-test-group",
         topics: ["kaffe-test"],
@@ -51,7 +52,7 @@ defmodule Kaffe.Config.ConsumerTest do
       }
 
       on_exit(fn ->
-        change_config("subscriber_name", fn(config) ->
+        change_config("subscriber_name", fn config ->
           Keyword.put(config, :sasl, sasl)
         end)
       end)
@@ -61,12 +62,13 @@ defmodule Kaffe.Config.ConsumerTest do
 
     test "string endpoints parsed correctly" do
       endpoints = Kaffe.Config.Consumer.config_get!("subscriber_name", :endpoints)
-      change_config("subscriber_name", fn(config) ->
+
+      change_config("subscriber_name", fn config ->
         config |> Keyword.put(:endpoints, "kafka:9092,localhost:9092")
       end)
 
       expected = %{
-        endpoints: [{'kafka', 9092}, {'localhost', 9092}],
+        endpoints: [{~c"kafka", 9092}, {~c"localhost", 9092}],
         subscriber_name: :subscriber_name,
         consumer_group: "kaffe-test-group",
         topics: ["kaffe-test"],
@@ -93,7 +95,7 @@ defmodule Kaffe.Config.ConsumerTest do
       }
 
       on_exit(fn ->
-        change_config("subscriber_name", fn(config) ->
+        change_config("subscriber_name", fn config ->
           Keyword.put(config, :endpoints, endpoints)
         end)
       end)
@@ -104,12 +106,13 @@ defmodule Kaffe.Config.ConsumerTest do
 
   test "correct settings with sasl plain are extracted" do
     sasl = Kaffe.Config.Consumer.config_get!("subscriber_name", :sasl)
-    change_config("subscriber_name", fn(config) ->
+
+    change_config("subscriber_name", fn config ->
       Keyword.put(config, :sasl, %{mechanism: :plain, login: "Alice", password: "ecilA"})
     end)
 
     expected = %{
-      endpoints: [{'kafka', 9092}],
+      endpoints: [{~c"kafka", 9092}],
       subscriber_name: :subscriber_name,
       consumer_group: "kaffe-test-group",
       topics: ["kaffe-test"],
@@ -137,7 +140,7 @@ defmodule Kaffe.Config.ConsumerTest do
     }
 
     on_exit(fn ->
-      change_config("subscriber_name", fn(config) ->
+      change_config("subscriber_name", fn config ->
         Keyword.put(config, :sasl, sasl)
       end)
     end)
@@ -147,12 +150,13 @@ defmodule Kaffe.Config.ConsumerTest do
 
   test "correct settings with ssl are extracted" do
     ssl = Kaffe.Config.Consumer.config_get("subscriber_name", :ssl, false)
-    change_config("subscriber_name", fn(config) ->
+
+    change_config("subscriber_name", fn config ->
       Keyword.put(config, :ssl, true)
     end)
 
     expected = %{
-      endpoints: [{'kafka', 9092}],
+      endpoints: [{~c"kafka", 9092}],
       subscriber_name: :subscriber_name,
       consumer_group: "kaffe-test-group",
       topics: ["kaffe-test"],
@@ -180,7 +184,7 @@ defmodule Kaffe.Config.ConsumerTest do
     }
 
     on_exit(fn ->
-      change_config("subscriber_name", fn(config) ->
+      change_config("subscriber_name", fn config ->
         Keyword.put(config, :ssl, ssl)
       end)
     end)
@@ -190,7 +194,7 @@ defmodule Kaffe.Config.ConsumerTest do
 
   describe "offset_reset_policy" do
     test "computes correctly from start_with_earliest_message == true" do
-      change_config("subscriber_name", fn(config) ->
+      change_config("subscriber_name", fn config ->
         config |> Keyword.delete(:offset_reset_policy)
       end)
 

--- a/test/kaffe/config/producer_test.exs
+++ b/test/kaffe/config/producer_test.exs
@@ -11,7 +11,7 @@ defmodule Kaffe.Config.ProducerTest do
       Application.put_env(:kaffe, :producer, no_sasl_config)
 
       expected = %{
-        endpoints: [{'kafka', 9092}],
+        endpoints: [{~c"kafka", 9092}],
         producer_config: [
           auto_start_producers: true,
           allow_topic_auto_creation: false,
@@ -43,7 +43,7 @@ defmodule Kaffe.Config.ProducerTest do
       Application.put_env(:kaffe, :producer, sasl_config)
 
       expected = %{
-        endpoints: [{'kafka', 9092}],
+        endpoints: [{~c"kafka", 9092}],
         producer_config: [
           auto_start_producers: true,
           allow_topic_auto_creation: false,
@@ -79,7 +79,7 @@ defmodule Kaffe.Config.ProducerTest do
     Application.put_env(:kaffe, :producer, Keyword.put(config, :endpoints, "kafka:9092,localhost:9092"))
 
     expected = %{
-      endpoints: [{'kafka', 9092}, {'localhost', 9092}],
+      endpoints: [{~c"kafka", 9092}, {~c"localhost", 9092}],
       producer_config: [
         auto_start_producers: true,
         allow_topic_auto_creation: false,
@@ -113,7 +113,7 @@ defmodule Kaffe.Config.ProducerTest do
     Application.put_env(:kaffe, :producer, Keyword.put(config, :ssl, true))
 
     expected = %{
-      endpoints: [{'kafka', 9092}],
+      endpoints: [{~c"kafka", 9092}],
       producer_config: [
         auto_start_producers: true,
         allow_topic_auto_creation: false,

--- a/test/kaffe/config_test.exs
+++ b/test/kaffe/config_test.exs
@@ -8,7 +8,7 @@ defmodule Kaffe.ConfigTest do
         "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
       )
 
-      expected = [{'192.168.1.100', 9096}, {'192.168.1.101', 9096}, {'192.168.1.102', 9096}]
+      expected = [{~c"192.168.1.100", 9096}, {~c"192.168.1.101", 9096}, {~c"192.168.1.102", 9096}]
 
       on_exit(fn ->
         System.delete_env("KAFKA_URL")
@@ -19,7 +19,7 @@ defmodule Kaffe.ConfigTest do
 
     test "transforms endpoints into the correct format" do
       kafka_url = "kafka+ssl://192.168.1.100:9096,kafka+ssl://192.168.1.101:9096,kafka+ssl://192.168.1.102:9096"
-      expected = [{'192.168.1.100', 9096}, {'192.168.1.101', 9096}, {'192.168.1.102', 9096}]
+      expected = [{~c"192.168.1.100", 9096}, {~c"192.168.1.101", 9096}, {~c"192.168.1.102", 9096}]
 
       assert Kaffe.Config.parse_endpoints(kafka_url) == expected
     end


### PR DESCRIPTION
I use kaffe with Elixir 1.18 and get many warnings from the compiler.
I propose to update the code to fix these warnings:

```
    warning: using single-quoted strings to represent charlists is deprecated.
    Use ~c"" if you indeed want a charlist or use "" instead.
    You may run "mix format --migrate" to change all single-quoted
    strings to use the ~c sigil and fix this warning.
```

```
     warning: redefining @doc attribute previously set at line 16.

     Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head (the function signature not followed by any do-block). For example:

         @doc """
         new docs
         """
         def handle_call(...)
```

Also applied some minor changes made by `mix format` automatically