### PR TITLE
Allow more brod config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.28.0
+
+* Allow `auto_start_producers` and `allow_topic_auto_creation` to be configurable for brod clients. If configuration of either of these values is desired, update your producer or consumer configs.
+
 # 1.27.2
 
 * Relax `:retry` requirement

--- a/README.md
+++ b/README.md
@@ -79,29 +79,7 @@ There is also legacy support for single message consumers, which process one mes
     end
     ```
 
-2. The configuration options for the `GroupMember` consumer are a superset of those for `Kaffe.Consumer`, except for `:async_message_ack`, which is not supported. The additional options are:
-
-	* `:rebalance_delay_ms` The time to allow for rebalancing among workers. The default is 10,000, which should give the consumers time to rebalance when scaling.
-
-	* `:max_bytes` Limits the number of message bytes received from Kafka for a particular topic subscriber. The default is 1MB. This parameter might need tuning depending on the number of partitions in the topics being read (there is one subscriber per topic per partition). For example, if you are reading from two topics, each with 32 partitions, there is the potential of 64MB in buffered messages at any one time.
-
-	* `:min_bytes` Sets a minimum threshold for the number of bytes to fetch for a batch of messages. The default is 0MB.
-
-	* `:max_wait_time` Sets the maximum number of milliseconds that the broker is allowed to collect min_bytes of messages in a batch of messages.
-
-	* `:offset_reset_policy` Controls how the subscriber handles an expired offset. See the Kafka consumer option, [`auto.offset.reset`](https://kafka.apache.org/documentation/#newconsumerconfigs). Valid values for this option are:
-
-		* `:reset_to_earliest` Reset to the earliest available offset.
-		* `:reset_to_latest` Reset to the latest offset.
-		* `:reset_by_subscriber` The subscriber receives the `OffsetOutOfRange` error.
-
-	More information in the [Brod consumer](https://github.com/klarna/brod/blob/master/src/brod_consumer.erl).
-
-	* `:worker_allocation_strategy` Controls how workers are allocated with respect to consumed topics and partitions.
-
-		* `:worker_per_partition` The default (for backward compatibilty) and allocates a single worker per partition across topics. This is useful for managing concurrent processing of messages that may be received from any consumed topic.
-
-		* `:worker_per_topic_partition` This strategy allocates a worker per topic partition. This means there will be a worker for every topic partition consumed. Unless you need to control concurrency across topics, you should use this strategy.
+2. The configuration options for the `GroupMember` consumer are a superset of those for `Kaffe.Consumer`. Additional options can be found in `Kaffe.Config.Consumer`.
 
       ```elixir
       config :kaffe,
@@ -306,7 +284,7 @@ It's possible that your topic and system are entirely ok with losing some messag
 
 `Kaffe.Producer` handles producing messages to Kafka and will automatically select the topic partitions per message or can be given a function to call to determine the partition per message. Kaffe automatically inserts a Kafka timestamp with each message.
 
-Configure your Kaffe Producer in your mix config
+Configure your Kaffe Producer in your mix config. For all options, see `Kaffe.Config.Producer`.
 
 ```elixir
 config :kaffe,

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -93,8 +93,8 @@ defmodule Kaffe.Config.Consumer do
 
   def default_client_consumer_config(config_key) do
     [
-      auto_start_producers: false,
-      allow_topic_auto_creation: false,
+      auto_start_producers: config_get(config_key, :auto_start_producers, false),
+      allow_topic_auto_creation: config_get(config_key, :allow_topic_auto_creation, false),
       begin_offset: begin_offset(config_key)
     ]
   end

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -1,4 +1,86 @@
 defmodule Kaffe.Config.Consumer do
+  @moduledoc """
+  Configuration for Kaffe consumers.
+
+  The configuration options for the `GroupMember` consumer are a superset of those for `Kaffe.Consumer`.
+
+  The full list of supported config can be found below.
+
+  * `:endpoints` The endpoints to consume from. Supports either host-port tuples (`[localhost: 9092]`,
+    as an example), or urls.
+
+  * `:heroku_kafka_env` Endpoints and SSL configuration will be pulled from ENV
+
+  * `:consumer_group` The kafka consumer group the consumer is in. Should be unique to your app.
+
+  * `:topics` A list of topics to consume from.
+
+  * `:message_handler` The configured module to receive messages from the consumer.
+
+  * `:async_message_ack` If false Kafka offset will automatically acknowledge after successful message parsing.
+    If `async_message_ack` is true then you'll need to call `ack/2` to acknowledge Kafka messages as processed.
+    Only use async processing if absolutely needed by your application's processing flow. With automatic (sync)
+    acknowledgement then the message flow from `Kaffe.Consumer` has backpressure from your system. With
+    manual (async) acknowledgement you will be able to process messages faster but will need to take on the burden
+    of ensuring no messages are lost.
+
+  * `:start_with_earliest_message` If true the worker will consume from the  beginning of the topic when it first
+    starts. This only affects consumer behavior before the consumer group starts recording its offsets in Kafka.
+
+  * `:auto_start_producers` If true, `brod` client will spawn a producer automatically when user is trying
+    to call produce but did not call brod:start_producer explicitly. Defaults to false. See `brod` documentation
+    for more details.
+
+  * `:allow_topic_auto_creation` By default, `brod` respects what is configured in the broker about topic auto-creation.
+    i.e. whether `auto.create.topics.enable` is set in the broker configuration. However if `allow_topic_auto_creation`
+    is set to false in client config, brod will avoid sending metadata requests that may cause an auto-creation of the
+    topic regardless of what broker config is. Defaults to false. See `brod` for more details.
+
+  * `:offset_commit_interval_seconds` Defines the time interval between two OffsetCommitRequest messages, defaulting
+    to 5 seconds.
+
+  * `:rebalance_delay_ms` The time to allow for rebalancing among workers. The default is 10,000, which should
+    give the consumers time to rebalance when scaling.
+
+  * `:max_bytes` Limits the number of message bytes received from Kafka for a particular topic subscriber. The
+    default is 1MB. This parameter might need tuning depending on the number of partitions in the topics being
+    read (there is one subscriber per topic per partition). For example, if you are reading from two topics, each
+    with 32 partitions, there is the potential of 64MB in buffered messages at any one time.
+
+  * `:min_bytes` Sets a minimum threshold for the number of bytes to fetch for a batch of messages. The default is 0MB.
+
+  * `:max_wait_time` Sets the maximum number of milliseconds that the broker is allowed to collect min_bytes of
+    messages in a batch of messages.
+
+  * `:subscriber_retries` The number of times a subscriber will retry subscribing to a topic. Defaults to 5.
+
+  * `:subscriber_retry_delay_ms` The ms a subscriber will delay connecting to a topic after a failure. Defaults to 5000.
+    This only matters when `subscriber_retries` is greater than 0.
+
+  * `:client_down_retry_expire` The amount of ms taken to attempt retries on a down client. Defaults to 30_000, and has
+    exponential backoff (currently not configurable).
+
+  * `:offset_reset_policy` Controls how the subscriber handles an expired offset. See the Kafka consumer
+    option, [`auto.offset.reset`](https://kafka.apache.org/documentation/#newconsumerconfigs). Valid values for
+    this option are:
+
+		* `:reset_to_earliest` Reset to the earliest available offset.
+		* `:reset_to_latest` Reset to the latest offset.
+		* `:reset_by_subscriber` The subscriber receives the `OffsetOutOfRange` error.
+
+  More information in the [Brod consumer](https://github.com/klarna/brod/blob/master/src/brod_consumer.erl).
+
+  * `:worker_allocation_strategy` Controls how workers are allocated with respect to consumed topics and partitions.
+
+		* `:worker_per_partition` The default (for backward compatibilty) and allocates a single worker per partition
+      across topics. This is useful for managing concurrent processing of messages that may be received from any
+      consumed topic.
+
+		* `:worker_per_topic_partition` This strategy allocates a worker per topic partition. This means there will be
+      a worker for every topic partition consumed. Unless you need to control concurrency across topics, you should
+      use this strategy.
+  """
+
   import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
   require Logger
 

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -24,7 +24,7 @@ defmodule Kaffe.Config.Consumer do
     manual (async) acknowledgement you will be able to process messages faster but will need to take on the burden
     of ensuring no messages are lost.
 
-  * `:start_with_earliest_message` If true the worker will consume from the  beginning of the topic when it first
+  * `:start_with_earliest_message` If true the worker will consume from the beginning of the topic when it first
     starts. This only affects consumer behavior before the consumer group starts recording its offsets in Kafka.
 
   * `:auto_start_producers` If true, `brod` client will spawn a producer automatically when user is trying

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -46,8 +46,8 @@ defmodule Kaffe.Config.Producer do
 
   def default_client_producer_config do
     [
-      auto_start_producers: true,
-      allow_topic_auto_creation: false,
+      auto_start_producers: config_get(:auto_start_producers, true),
+      allow_topic_auto_creation: config_get(:allow_topic_auto_creation, false),
       default_producer_config: [
         required_acks: config_get(:required_acks, -1),
         ack_timeout: config_get(:ack_timeout, 1000),

--- a/lib/kaffe/config/producer.ex
+++ b/lib/kaffe/config/producer.ex
@@ -1,4 +1,61 @@
 defmodule Kaffe.Config.Producer do
+  @moduledoc """
+  Configuration for Kaffe producers.
+
+  * `:heroku_kafka_env` Endpoints and SSL configuration will be pulled from ENV
+
+  * `:endpoints` The endpoints to produce to. Supports either host-port tuples (`[localhost: 9092]`,
+    as an example), or urls.
+
+  * `:topics` a list of Kafka topics to prep for producing
+
+  * `:partition_strategy` The strategy to use when selecting the next partition. Defaults to `:md5`.
+    * `:md5`: provides even and deterministic distrbution of the messages over the available partitions based
+      on an MD5 hash of the key
+    * `:random` - Select a random partition
+    * function - Pass a function as an argument that accepts five arguments and returns the partition number
+      to use for the message
+        * The args are `topic, current_partition, partitions_count, key, value`
+
+  * `:auto_start_producers` If true, `brod` client will spawn a producer automatically when user is trying
+    to call produce but did not call brod:start_producer explicitly. Defaults to true. See `brod` documentation
+    for more details.
+
+  * `:allow_topic_auto_creation` By default, `brod` respects what is configured in the broker about topic auto-creation.
+    i.e. whether `auto.create.topics.enable` is set in the broker configuration. However if `allow_topic_auto_creation`
+    is set to false in client config, brod will avoid sending metadata requests that may cause an auto-creation of the
+    topic regardless of what broker config is. Defaults to false. See `brod` for more details.
+
+  * `:required_acks` How many acknowledgements the kafka broker should receive from the clustered replicas before
+    acking producer. Defaults to -1. See brod for more details.
+     * 0: the broker will not send any response (this is the only case where the broker will not reply to a request)
+     * 1: The leader will wait the data is written to the local log before sending a response.
+     * -1: If it is -1 the broker will block until the message is committed by all in sync replicas before acking.
+
+  * `:ack_timeout` Maximum time in milliseconds the broker can await the receipt of the number of
+    acknowledgements in `required_acks'. The timeout is not an exact limit on the request time. Defaults to 1000.
+    See `brod` for more details.
+
+  * `:partition_buffer_limit` How many requests (per-partition) can be buffered without blocking the caller.
+    Defaults to 512. See `brod` for more details.
+
+  * `:partition_onwire_limit`  How many message sets (per-partition) can be sent to kafka broker asynchronously
+    before receiving ACKs from broker. Setting a number greater than 1 may cause messages being persisted in an
+    order different from the order they were produced. Defaults to 1. See `brod` for more details.
+
+  * `:max_batch_size` The number of bytes to batch produced messages to brokers in case callers are producing faster
+    than brokers can handle. If compression is enabled, care should be taken when picking the max batch size, because
+    a compressed batch will be produced as one message and this message might be larger than 'max.message.bytes'
+    in kafka config (or topic config). See `brod` for more details.
+
+  * `:max_retries` The number of times to retry message production. Defaults to 3. See `brod` for more details.
+
+  * `:retry_backoff_ms` The number of ms to wait between retries. Defaults to 500. See `brod` for more details.
+
+  * `:compression` The compression algorithm to use. Possible values are `:gzip`, `:no_compression`, or `:snappy`.
+    Defaults to `:no_compression`.
+  """
+
   import Kaffe.Config, only: [heroku_kafka_endpoints: 0, parse_endpoints: 1]
 
   def configuration do

--- a/lib/kaffe/consumer.ex
+++ b/lib/kaffe/consumer.ex
@@ -39,27 +39,8 @@ defmodule Kaffe.Consumer do
   @doc """
   Start a Kafka consumer
 
-  The consumer pulls in values from the Kaffe consumer configuration:
-
-    - `heroku_kafka_env` - endpoints and SSL configuration will be pulled from ENV
-    - `endpoints` - plaintext Kafka endpoints
-    - `consumer_group` - the consumer group id (should be unique to your app)
-    - `topics` - a list of Kafka topics to consume
-    - `message_handler` - the module that will be called for each Kafka message
-    - `async_message_ack` - if false Kafka offset will automatically acknowledge
-      after successful message parsing
-    - `start_with_earliest_message` - If true the worker will consume from the
-      beginning of the topic when it first starts. This only affects consumer
-      behavior before the consumer group starts recording its offsets in Kafka.
-
-  Note: If `async_message_ack` is true then you'll need to call `ack/2` to
-  acknowledge Kafka messages as processed.
-
-  Only use async processing if absolutely needed by your application's
-  processing flow. With automatic (sync) acknowledgement then the message flow
-  from `Kaffe.Consumer` has backpressure from your system. With manual (async)
-  acknowledgement you will be able to process messages faster but will need to
-  take on the burden of ensuring no messages are lost.
+  The consumer pulls in values from the Kaffe consumer configuration. See more
+  details at `Kaffe.Config.Consumer`.
   """
   def start_link(config_key) do
     config = Kaffe.Config.Consumer.configuration(config_key)

--- a/lib/kaffe/producer.ex
+++ b/lib/kaffe/producer.ex
@@ -1,18 +1,8 @@
 defmodule Kaffe.Producer do
   @moduledoc """
 
-  The producer pulls in values from the Kaffe producer configuration:
-
-    - `heroku_kafka_env` - endpoints and SSL configuration will be pulled from ENV
-    - `endpoints` - plaintext Kafka endpoints
-    - `topics` - a list of Kafka topics to prep for producing
-    - `partition_strategy` - the strategy to use when selecting the next partition.
-      Default `:md5`.
-      - `:md5`: provides even and deterministic distrbution of the messages over the available partitions based on an MD5 hash of the key
-      - `:random` - Select a random partition
-      - function - Pass a function as an argument that accepts five arguments and
-        returns the partition number to use for the message
-          - `topic, current_partition, partitions_count, key, value`
+  The producer pulls in values from the Kaffe producer configuration. See `Kaffe.Config.Producer` for a list
+  of options.
 
   Clients can also specify a partition directly when producing.
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Kaffe.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/spreedly/kaffe"
-  @version "1.27.2"
+  @version "1.28.0"
 
   def project do
     [


### PR DESCRIPTION
`auto_start_producers` and `allow_topic_auto_creation` are no longer hard coded, and can be configured per client (producer or consumer).

This also bumps the version to 1.28.0

Resolves #151 