### PR TITLE
Support more consumer options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.2.0
+
+* Adds more brod configuration options: `sleep_timeout`, `prefetch_bytes`, and `prefetch_count`. See `:brod_consumer` for more info
+about how these are used.
+
 # 2.1.0
 
 * Removes crc32cer version limit. Bumping to > 1.0.0 requires cmake, so some may want to limit crc32cer themselves in mix.exs.

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -52,6 +52,9 @@ defmodule Kaffe.Config.Consumer do
   * `:max_wait_time` Sets the maximum number of milliseconds that the broker is allowed to collect min_bytes of
     messages in a batch of messages.
 
+  * `:sleep_timeout` Allows consumer process to sleep this amount of ms if kafka replied 'empty' message set.
+    The default is 1s.
+
   * `:subscriber_retries` The number of times a subscriber will retry subscribing to a topic. Defaults to 5.
 
   * `:subscriber_retry_delay_ms` The ms a subscriber will delay connecting to a topic after a failure. Defaults to 5000.
@@ -98,6 +101,7 @@ defmodule Kaffe.Config.Consumer do
       max_bytes: max_bytes(config_key),
       min_bytes: min_bytes(config_key),
       max_wait_time: max_wait_time(config_key),
+      sleep_timeout: sleep_timeout(config_key),
       subscriber_retries: subscriber_retries(config_key),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(config_key),
       offset_reset_policy: offset_reset_policy(config_key),
@@ -146,6 +150,10 @@ defmodule Kaffe.Config.Consumer do
 
   def max_wait_time(config_key) do
     config_get(config_key, :max_wait_time, 10_000)
+  end
+
+  def sleep_timeout(config_key) do
+    config_get(config_key, :sleep_timeout, 1_000)
   end
 
   def subscriber_retries(config_key) do

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -55,6 +55,12 @@ defmodule Kaffe.Config.Consumer do
   * `:sleep_timeout` Allows consumer process to sleep this amount of ms if kafka replied 'empty' message set.
     The default is 1s.
 
+  * `:prefetch_count` Sets the window size (number of messages) allowed to fetch-ahead. The default is 10 messages.
+
+  * `:prefetch_bytes` Sets the total number of bytes allowed to fetch-ahead. `brod_consumer` is greed, it only stops
+    fetching more messages in when number of unacked messages has exceeded `prefetch_count` AND the unacked total
+    volume has exceeded `prefetch_bytes`. The default is 100KB.
+
   * `:subscriber_retries` The number of times a subscriber will retry subscribing to a topic. Defaults to 5.
 
   * `:subscriber_retry_delay_ms` The ms a subscriber will delay connecting to a topic after a failure. Defaults to 5000.
@@ -102,6 +108,8 @@ defmodule Kaffe.Config.Consumer do
       min_bytes: min_bytes(config_key),
       max_wait_time: max_wait_time(config_key),
       sleep_timeout: sleep_timeout(config_key),
+      prefetch_count: prefetch_count(config_key),
+      prefetch_bytes: prefetch_bytes(config_key),
       subscriber_retries: subscriber_retries(config_key),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(config_key),
       offset_reset_policy: offset_reset_policy(config_key),
@@ -154,6 +162,14 @@ defmodule Kaffe.Config.Consumer do
 
   def sleep_timeout(config_key) do
     config_get(config_key, :sleep_timeout, 1_000)
+  end
+
+  def prefetch_count(config_key) do
+    config_get(config_key, :prefetch_count, 10)
+  end
+
+  def prefetch_bytes(config_key) do
+    config_get(config_key, :prefetch_bytes, 102_400)
   end
 
   def subscriber_retries(config_key) do

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -55,6 +55,12 @@ defmodule Kaffe.Config.Consumer do
   * `:sleep_timeout` Allows consumer process to sleep this amount of ms if kafka replied 'empty' message set.
     The default is 1s.
 
+  * `:prefetch_count` Sets the window size (number of messages) allowed to fetch-ahead. The default is 10 messages.
+
+  * `:prefetch_bytes` Sets the total number of bytes allowed to fetch-ahead. `brod_consumer` is greed, it only stops
+    fetching more messages in when number of unacked messages has exceeded `prefetch_count` AND the unacked total
+    volume has exceeded `prefetch_bytes`. The default is 100KB.
+
   * `:subscriber_retries` The number of times a subscriber will retry subscribing to a topic. Defaults to 5.
 
   * `:subscriber_retry_delay_ms` The ms a subscriber will delay connecting to a topic after a failure. Defaults to 5000.
@@ -102,6 +108,8 @@ defmodule Kaffe.Config.Consumer do
       min_bytes: min_bytes(config_key),
       max_wait_time: max_wait_time(config_key),
       sleep_timeout: sleep_timeout(config_key),
+      prefetch_count: prefetch_count(config_key),
+      prefetch_bytes: prefetch_bytes(config_key),
       subscriber_retries: subscriber_retries(config_key),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(config_key),
       offset_reset_policy: offset_reset_policy(config_key),
@@ -157,6 +165,14 @@ defmodule Kaffe.Config.Consumer do
 
   def sleep_timeout(config_key) do
     config_get(config_key, :sleep_timeout, 1_000)
+  end
+
+  def prefetch_count(config_key) do
+    config_get(config_key, :prefetch_count, 10)
+  end
+
+  def prefetch_bytes(config_key) do
+    config_get(config_key, :prefetch_bytes, 102_400)
   end
 
   def subscriber_retries(config_key) do

--- a/lib/kaffe/config/consumer.ex
+++ b/lib/kaffe/config/consumer.ex
@@ -52,6 +52,9 @@ defmodule Kaffe.Config.Consumer do
   * `:max_wait_time` Sets the maximum number of milliseconds that the broker is allowed to collect min_bytes of
     messages in a batch of messages.
 
+  * `:sleep_timeout` Allows consumer process to sleep this amount of ms if kafka replied 'empty' message set.
+    The default is 1s.
+
   * `:subscriber_retries` The number of times a subscriber will retry subscribing to a topic. Defaults to 5.
 
   * `:subscriber_retry_delay_ms` The ms a subscriber will delay connecting to a topic after a failure. Defaults to 5000.
@@ -98,6 +101,7 @@ defmodule Kaffe.Config.Consumer do
       max_bytes: max_bytes(config_key),
       min_bytes: min_bytes(config_key),
       max_wait_time: max_wait_time(config_key),
+      sleep_timeout: sleep_timeout(config_key),
       subscriber_retries: subscriber_retries(config_key),
       subscriber_retry_delay_ms: subscriber_retry_delay_ms(config_key),
       offset_reset_policy: offset_reset_policy(config_key),
@@ -149,6 +153,10 @@ defmodule Kaffe.Config.Consumer do
 
   def max_wait_time(config_key) do
     config_get(config_key, :max_wait_time, 10_000)
+  end
+
+  def sleep_timeout(config_key) do
+    config_get(config_key, :sleep_timeout, 1_000)
   end
 
   def subscriber_retries(config_key) do

--- a/lib/kaffe/consumer_group/subscriber/subscriber.ex
+++ b/lib/kaffe/consumer_group/subscriber/subscriber.ex
@@ -235,6 +235,9 @@ defmodule Kaffe.Subscriber do
 
   defp subscriber_ops(config) do
     [
+      sleep_timeout: config.sleep_timeout,
+      prefetch_count: config.prefetch_count,
+      prefetch_bytes: config.prefetch_bytes,
       max_bytes: config.max_bytes,
       min_bytes: config.min_bytes,
       max_wait_time: config.max_wait_time,

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Kaffe.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/spreedly/kaffe"
-  @version "2.1.0"
+  @version "2.2.0"
 
   def project do
     [

--- a/test/kaffe/config/consumer_test.exs
+++ b/test/kaffe/config/consumer_test.exs
@@ -48,7 +48,10 @@ defmodule Kaffe.Config.ConsumerTest do
         subscriber_retry_delay_ms: 5,
         offset_reset_policy: :reset_by_subscriber,
         worker_allocation_strategy: :worker_per_partition,
-        client_down_retry_expire: 15_000
+        client_down_retry_expire: 15_000,
+        prefetch_bytes: 102_400,
+        prefetch_count: 10,
+        sleep_timeout: 1000
       }
 
       on_exit(fn ->
@@ -91,7 +94,10 @@ defmodule Kaffe.Config.ConsumerTest do
         subscriber_retry_delay_ms: 5,
         offset_reset_policy: :reset_by_subscriber,
         worker_allocation_strategy: :worker_per_partition,
-        client_down_retry_expire: 15_000
+        client_down_retry_expire: 15_000,
+        prefetch_bytes: 102_400,
+        prefetch_count: 10,
+        sleep_timeout: 1000
       }
 
       on_exit(fn ->
@@ -136,7 +142,10 @@ defmodule Kaffe.Config.ConsumerTest do
       subscriber_retry_delay_ms: 5,
       offset_reset_policy: :reset_by_subscriber,
       worker_allocation_strategy: :worker_per_partition,
-      client_down_retry_expire: 15_000
+      client_down_retry_expire: 15_000,
+      prefetch_bytes: 102_400,
+      prefetch_count: 10,
+      sleep_timeout: 1000
     }
 
     on_exit(fn ->
@@ -180,7 +189,10 @@ defmodule Kaffe.Config.ConsumerTest do
       subscriber_retry_delay_ms: 5,
       offset_reset_policy: :reset_by_subscriber,
       worker_allocation_strategy: :worker_per_partition,
-      client_down_retry_expire: 15_000
+      client_down_retry_expire: 15_000,
+      prefetch_bytes: 102_400,
+      prefetch_count: 10,
+      sleep_timeout: 1000
     }
 
     on_exit(fn ->


### PR DESCRIPTION
This PR adds support for the following `brod_consumer`opts:
* sleep_timeout (default: 1000ms)
* prefetch_bytes (default: 100KB)
* prefetch_count (default: 10)

They are useful when you want to optimise the consumer, and I'm not sure why Kaffe doesn't allow you to configure them